### PR TITLE
feat(environment-setup): add rust cache + diagnostics

### DIFF
--- a/actions/environment-setup/action.yml
+++ b/actions/environment-setup/action.yml
@@ -194,6 +194,7 @@ runs:
           echo "setup_docker=false" >> "$GITHUB_OUTPUT"
           echo "setup_services=false" >> "$GITHUB_OUTPUT"
           echo "setup_system_packages=false" >> "$GITHUB_OUTPUT"
+          echo "setup_rust=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
         
@@ -361,6 +362,29 @@ runs:
         fi
 
         # ────────────────────────────────────────────────────────────────────────
+        # Parse Rust configuration
+        # ────────────────────────────────────────────────────────────────────────
+        # Schema in .environment.yml:
+        #   rust:
+        #     cache: true         # enable Swatinem/rust-cache for target/ dirs
+        #     diagnostics: true   # print cargo/rust env info pre-job
+        # The Rust toolchain itself is expected to be managed by
+        # rust-toolchain.toml at the repo root (rustup auto-installs on
+        # first cargo invocation). This section only wires up caching and
+        # diagnostic prints.
+        RUST_CONFIG=$(yq -e '.rust // false' "$CONFIG_FILE" 2>/dev/null || echo "false")
+        if [[ "$RUST_CONFIG" != "false" && "$RUST_CONFIG" != "null" ]] && should_setup "rust"; then
+          echo "setup_rust=true" >> "$GITHUB_OUTPUT"
+          RUST_CACHE=$(yq -e '.rust.cache // true' "$CONFIG_FILE" 2>/dev/null || echo "true")
+          RUST_DIAG=$(yq -e '.rust.diagnostics // false' "$CONFIG_FILE" 2>/dev/null || echo "false")
+          echo "rust_cache=$RUST_CACHE" >> "$GITHUB_OUTPUT"
+          echo "rust_diagnostics=$RUST_DIAG" >> "$GITHUB_OUTPUT"
+          echo "  ✓ Rust: cache=$RUST_CACHE, diagnostics=$RUST_DIAG"
+        else
+          echo "setup_rust=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        # ────────────────────────────────────────────────────────────────────────
         # Parse Services configuration
         # ────────────────────────────────────────────────────────────────────────
         SERVICES_CONFIG=$(yq -e '.services // {}' "$CONFIG_FILE" 2>/dev/null || echo "{}")
@@ -459,6 +483,48 @@ runs:
       shell: bash
       run: |
         echo "::warning::system_packages is only supported on Linux runners; ignoring on ${{ runner.os }}."
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # 🦀 RUST — cache and diagnostics
+    # ══════════════════════════════════════════════════════════════════════════
+    # Toolchain comes from the repo's rust-toolchain.toml (rustup auto-installs
+    # on first cargo invocation). This section provides caching and optional
+    # diagnostic prints.
+
+    - name: Rust diagnostics
+      if: steps.config.outputs.setup_rust == 'true' && steps.config.outputs.rust_diagnostics == 'true'
+      shell: bash
+      run: |
+        echo "🦀 Rust environment diagnostics"
+        echo "─────────────────────────────────"
+        echo "Runner: ${{ runner.os }} / ${{ runner.arch }}"
+        echo "CPU: $(nproc) cores"
+        echo "Memory:"
+        free -h 2>/dev/null | sed 's/^/  /'
+        echo "Disk (root):"
+        df -h / 2>/dev/null | sed 's/^/  /'
+        echo "Cargo: $(cargo --version 2>&1)"
+        echo "Rustup:"
+        rustup show 2>&1 | sed 's/^/  /'
+        echo "Network (ping crates.io):"
+        curl -sSfI -m 5 https://crates.io/ 2>&1 | head -3 | sed 's/^/  /'
+        if [[ -f Cargo.toml ]]; then
+          echo "Cargo workspace members:"
+          cargo metadata --no-deps --format-version 1 2>/dev/null \
+            | python3 -c "import sys, json; d = json.load(sys.stdin); print(*(f'  - {p[\"name\"]}' for p in d['packages']), sep='\n')" \
+            | head -40
+        fi
+
+    - name: Cache cargo registry + target
+      if: steps.config.outputs.setup_rust == 'true' && steps.config.outputs.rust_cache == 'true'
+      uses: Swatinem/rust-cache@v2
+      with:
+        # Save cache even if the job fails — a partial cache is still faster
+        # than no cache for the next run.
+        save-if: true
+        # Share cache across all jobs in the same workflow, not just the
+        # branch. This lets parallel workflows re-use each other's caches.
+        shared-key: "rust-workspace"
 
     # ══════════════════════════════════════════════════════════════════════════
     # 🐳 DOCKER SETUP
@@ -629,4 +695,8 @@ runs:
 
         if [[ "${{ steps.config.outputs.setup_system_packages }}" == "true" ]]; then
           echo "| System packages (apt) | ✅ ${{ steps.config.outputs.system_packages }} |" >> $GITHUB_STEP_SUMMARY
+        fi
+
+        if [[ "${{ steps.config.outputs.setup_rust }}" == "true" ]]; then
+          echo "| Rust | ✅ cache=${{ steps.config.outputs.rust_cache }}, diagnostics=${{ steps.config.outputs.rust_diagnostics }} |" >> $GITHUB_STEP_SUMMARY
         fi


### PR DESCRIPTION
Adds a `rust:` section to .environment.yml with `cache` (Swatinem/rust-cache) and `diagnostics` (env pre-print). Unblocks mcpg-dev where cold-build Rust CI was running past 30m.