### PR TITLE
feat(nx-ci): add `ref` input + document versioning & concurrency

### DIFF
--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -205,6 +205,22 @@ on:
         default: true
 
       # ─────────────────────────────────────────────────────────────────────────
+      # Git Configuration
+      # ─────────────────────────────────────────────────────────────────────────
+      ref:
+        description: |
+          Git ref to checkout (branch, tag, or SHA).
+          Leave empty to use the triggering ref (default behavior — i.e. the
+          PR head for `pull_request`, the pushed ref for `push`, etc.).
+
+          Useful for scheduled/workflow_dispatch callers that need to test a
+          specific branch rather than the default branch the cron fires from.
+          Mirrors the `ref` input already exposed by nx-cd.yml.
+        required: false
+        type: string
+        default: ""
+
+      # ─────────────────────────────────────────────────────────────────────────
       # Runner Configuration
       # ─────────────────────────────────────────────────────────────────────────
       runs_on:
@@ -324,6 +340,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       # ════════════════════════════════════════════════════════════════════════
       # 🔄 NX AFFECTED DETECTION

--- a/README.md
+++ b/README.md
@@ -74,9 +74,17 @@ permissions:
   contents: read
   checks: write
 
+# Cancel superseded runs on the same PR / branch so a fast follow-up push
+# doesn't double up on runners. Set at the *caller* level — reusable workflows
+# run as part of the caller's run, so this is the authoritative place to
+# control cancellation.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
-    uses: tsok-org/.github/.github/workflows/nx-ci.yml@main
+    uses: tsok-org/.github/.github/workflows/nx-ci.yml@v1
     with:
       lint: true
       test: true
@@ -84,6 +92,14 @@ jobs:
     secrets:
       nx_cloud_access_token: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 ```
+
+> **Versioning.** Prefer pinning reusable workflows to a released tag
+> (`@v1`, `@v1.2.3`) rather than `@main`. `@main` tracks the tip of this
+> repo and an accidental breakage propagates instantly to all consumers.
+> Composite actions inside reusable workflows (e.g. `environment-setup`)
+> still use floating refs today — that is an explicit trade-off so the
+> `v1` contract protects the *outer* workflow surface, which is what
+> consumers actually depend on.
 
 ### 3. Create CD workflow
 


### PR DESCRIPTION
## Summary

Three small shared-CI dev-experience improvements bundled because they're part of the same pattern:

1. **Add `ref` input to `nx-ci.yml`** — mirrors the existing input on `nx-cd.yml`. Lets scheduled / `workflow_dispatch` callers target a non-default branch without inlining checkout. Discovered while building a nightly integration lane in `mcpg-dev/source-code` — scheduled workflows only fire on the default branch, so without a `ref` input the reusable CI can't validate `develop`.

2. **Quick Start README shows caller-level `concurrency:`** so new consumers adopt cancel-in-progress by default. Reusable workflows run inside the caller's run — the caller is the correct place to set concurrency, noted in the example comment.

3. **Quick Start README switches example to `@v1`** plus a Versioning note. Once `v1` is tagged (next step after merge), consumers get a stable outer contract. Composite actions inside (environment-setup, etc.) keep floating refs intentionally — pinning those would require re-tagging on every internal change; the trade-off is called out in the README.

## Compatibility

`ref` defaults to `github.ref`, so existing callers without the input behave identically. No breaking changes.

## Follow-up

- Tag `v1` on main after merge
- Migrate `mcpg-dev/source-code` consumer from `@main` → `@v1`
- Migrate inline nightly integration workflow to use nx-ci.yml with the new `ref` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)