### PR TITLE
feat(env-setup): add rust.sccache opt-in for per-object compile cache

### DIFF
--- a/actions/environment-setup/action.yml
+++ b/actions/environment-setup/action.yml
@@ -394,6 +394,20 @@ runs:
       with:
         tool: cargo-llvm-cov
 
+    - name: Setup sccache (compiler cache, GitHub Actions backend)
+      if: steps.config.outputs.setup_rust == 'true' && steps.config.outputs.rust_sccache == 'true'
+      # mozilla-actions/sccache-action installs the sccache binary and sets
+      # the env vars cargo needs: RUSTC_WRAPPER=sccache + SCCACHE_GHA_ENABLED=true.
+      # The GitHub Actions cache is used as the backend — no external storage
+      # required, scoped per-repo. Complements Swatinem/rust-cache: rust-cache
+      # restores target/ wholesale, sccache fills in per-object gaps when a
+      # partial rebuild is triggered (dep bump, profile change, etc.).
+      #
+      # Requires CARGO_INCREMENTAL=0 in the environment (sccache warns and
+      # silently bypasses when incremental is on). nx-ci.yml sets this by
+      # default; standalone consumers should ensure it's set in their env.
+      uses: mozilla-actions/sccache-action@v0.0.9
+
     - name: Apply Rust build knobs (CARGO_BUILD_JOBS, linker)
       if: steps.config.outputs.setup_rust == 'true'
       shell: bash

--- a/actions/environment-setup/schema.json
+++ b/actions/environment-setup/schema.json
@@ -93,6 +93,10 @@
           "type": "string",
           "enum": ["lld", "mold"],
           "description": "Alternative linker. lld = memory-lighter; mold = fastest + smallest memory."
+        },
+        "sccache": {
+          "type": "boolean",
+          "description": "Install sccache (via mozilla-actions/sccache-action) and wire RUSTC_WRAPPER. Uses the GitHub Actions cache as backend. Complements Swatinem/rust-cache — rust-cache restores target/ whole, sccache caches per-object so partial rebuilds (e.g. after a dep bump) are faster. Sets SCCACHE_GHA_ENABLED=true automatically."
         }
       }
     },

--- a/actions/environment-setup/scripts/parse-config.sh
+++ b/actions/environment-setup/scripts/parse-config.sh
@@ -250,12 +250,14 @@ if [[ "$RUST_CONFIG" != "false" ]] && should_setup "rust"; then
     RUST_JOBS=$(yq_get '.rust.build_jobs // ""' "")
     RUST_LINKER=$(yq_get '.rust.linker // ""' "")
     RUST_COVERAGE=$(yq_get '.rust.coverage' "false")
+    RUST_SCCACHE=$(yq_get '.rust.sccache' "false")
     out "rust_cache=$RUST_CACHE"
     out "rust_diagnostics=$RUST_DIAG"
     out "rust_build_jobs=$RUST_JOBS"
     out "rust_linker=$RUST_LINKER"
     out "rust_coverage=$RUST_COVERAGE"
-    echo "  ✓ Rust: cache=$RUST_CACHE, diagnostics=$RUST_DIAG, build_jobs=${RUST_JOBS:-auto}, linker=${RUST_LINKER:-default}, coverage=$RUST_COVERAGE"
+    out "rust_sccache=$RUST_SCCACHE"
+    echo "  ✓ Rust: cache=$RUST_CACHE, diagnostics=$RUST_DIAG, build_jobs=${RUST_JOBS:-auto}, linker=${RUST_LINKER:-default}, coverage=$RUST_COVERAGE, sccache=$RUST_SCCACHE"
 else
     out "setup_rust=false"
 fi


### PR DESCRIPTION
## Summary

Adds `.environment.yml` field `rust.sccache: true` that wires up `mozilla-actions/sccache-action` with the GitHub Actions cache as backend. `RUSTC_WRAPPER=sccache` + `SCCACHE_GHA_ENABLED=true` set automatically.

## Why not just rely on Swatinem/rust-cache?

Different layers:
- **rust-cache** restores `target/` wholesale when the cache key matches (`Cargo.lock` + `rust-toolchain.toml` unchanged).
- **sccache** fills per-object gaps during *partial* rebuilds — after a dep bump that changes the cache key, rust-cache misses, but most transitive `.rlib`s are still reusable. sccache pulls them from its object-level cache.

They coexist cleanly. Both together > either alone.

## Contract

- Field: `rust.sccache` boolean, default `false` (opt-in).
- No effect unless `rust` is also set.
- Requires `CARGO_INCREMENTAL=0` in caller env (sccache bypasses otherwise). `nx-ci.yml` already enforces this.

## Plan after merge

- Tag `v1.3.0`, move `v1`.
- Enable on `mcpg-dev/source-code` as Tier 1.4 of its perf roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)