### PR TITLE
fix(nx-ci): coverage=true still runs `test` on every affected project

### DIFF
--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -437,13 +437,21 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          # When coverage: true, run the project's `test:coverage` target
-          # (e.g., `cargo llvm-cov` for Rust, `jest --coverage` for TS)
-          # instead of the plain `test` target. This avoids the old
-          # approach of appending `--coverage` to the test command, which
-          # broke for cargo (cargo test has no --coverage flag).
+          # Always run `test` on every affected project so no crate is skipped.
+          # When coverage: true, ALSO run `test:coverage` on any project that
+          # has that target defined — that's the project-specific instrumented
+          # test run (e.g. `cargo llvm-cov` for Rust) which produces lcov.info.
+          #
+          # Nx's comma-separated target list runs both in one invocation;
+          # projects without `test:coverage` just skip that half. A project
+          # like Rust's mcpg with both targets will run tests twice — once
+          # plain and once instrumented — which is fast and correct.
+          #
+          # Prior behavior replaced `test` with `test:coverage` when coverage
+          # was true; that silently skipped every crate without a dedicated
+          # coverage target (e.g. 27 of 28 crates in the MCPG workspace).
           if [ "${{ inputs.coverage }}" == "true" ]; then
-            CMD="$CMD -t test:coverage --parallel=${{ inputs.parallel }}"
+            CMD="$CMD -t test,test:coverage --parallel=${{ inputs.parallel }}"
           else
             CMD="$CMD -t test --parallel=${{ inputs.parallel }}"
           fi


### PR DESCRIPTION
## Bug

When `coverage: true`, the workflow REPLACED `-t test` with `-t test:coverage` in the Run tests step. That silently skipped every project without a dedicated `test:coverage` target.

Impact on MCPG consumer: **27 of 28 Rust crates were not being tested at all** in CI — only `apps/mcpg` (which defined `test:coverage`) ran anything. Plugins, libs, and the secondary app never executed their test suites.

## Fix

Run both targets comma-separated:

```
-t test,test:coverage
```

Nx gracefully skips projects that don't define a target. Projects with both (e.g. `apps/mcpg`) run tests twice — once plain, once instrumented — which is fast relative to compile time.

## Verification

`@monodon/rust` does NOT auto-generate `test` or `build` targets; it only provides executors + dep graph + `nx-release-publish`. So the manual `nx:run-commands` `test` targets in consumer project.json files are the canonical test path — we just weren't running them when coverage was on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)