### PR TITLE
fix(nx-ci): unify on one `test` target; coverage gates upload only

### DIFF
--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -437,24 +437,12 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          # Always run `test` on every affected project so no crate is skipped.
-          # When coverage: true, ALSO run `test:coverage` on any project that
-          # has that target defined — that's the project-specific instrumented
-          # test run (e.g. `cargo llvm-cov` for Rust) which produces lcov.info.
-          #
-          # Nx's comma-separated target list runs both in one invocation;
-          # projects without `test:coverage` just skip that half. A project
-          # like Rust's mcpg with both targets will run tests twice — once
-          # plain and once instrumented — which is fast and correct.
-          #
-          # Prior behavior replaced `test` with `test:coverage` when coverage
-          # was true; that silently skipped every crate without a dedicated
-          # coverage target (e.g. 27 of 28 crates in the MCPG workspace).
-          if [ "${{ inputs.coverage }}" == "true" ]; then
-            CMD="$CMD -t test,test:coverage --parallel=${{ inputs.parallel }}"
-          else
-            CMD="$CMD -t test --parallel=${{ inputs.parallel }}"
-          fi
+          # One unified `test` target per project. Coverage is a property of
+          # the test target itself (e.g. a project whose `test` runs
+          # `cargo llvm-cov ...` produces lcov.info as a side effect); the
+          # `coverage` input on this workflow only gates whether we *upload*
+          # those lcov artifacts downstream, not which target we run.
+          CMD="$CMD -t test --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"


### PR DESCRIPTION
## Changing from v1.3.1

v1.3.1 ran both `-t test,test:coverage` so no crate was skipped. Consumer feedback: having two overlapping targets is awkward. Prefer a single `test` target whose implementation is instrumented (cargo-llvm-cov etc.) when coverage is needed.

## New behavior

Always run `-t test`. `coverage: true` now only gates the artifact upload step — it doesn't select which target runs. Projects whose `test` target happens to emit `lcov.info` (because it runs `cargo llvm-cov` rather than `cargo test`) get uploaded naturally.

## Consumer migration

- Delete `test:coverage` targets.
- Move the llvm-cov / jest --coverage invocation into the single `test` target.
- Upload glob (`**/lcov.info`) is unchanged and still catches whatever the test target produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)