### PR TITLE
refactor(env-setup): unify daemon install under `services`, drop container variant

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -230,7 +230,8 @@ jobs:
           assert "setup_docker=false"
           assert "setup_terraform=false"
           assert "setup_system_packages=false"
-          assert "setup_services=false"
+          assert "service_redis=false"
+          assert "service_nats=false"
           echo "node-only: single-language path clean."
 
       - name: Assert outputs (python-poetry)
@@ -301,7 +302,7 @@ jobs:
         id: env_setup
         uses: ./actions/environment-setup
         with:
-          skip: node,python,terraform,docker,services,system_packages,rust,go,c
+          skip: node,python,terraform,docker,system_packages,rust,go,c
 
       - name: Assert action short-circuited cleanly
         if: matrix.fixture.expect == 'pass'
@@ -317,7 +318,7 @@ jobs:
           # honored for that component (regression).
           fail=0
           for key in setup_node setup_python setup_rust setup_go setup_c \
-                     setup_docker setup_terraform setup_services \
+                     setup_docker setup_terraform \
                      setup_system_packages; do
             actual=$(jq -r --arg k "$key" '.[$k] // "<missing>"' <<<"$OUTPUTS_JSON")
             if [[ "$actual" != "false" ]]; then

--- a/actions/environment-setup/action.yml
+++ b/actions/environment-setup/action.yml
@@ -97,9 +97,12 @@ outputs:
   setup_docker:
     description: "Whether Docker setup ran (true/false)"
     value: ${{ steps.config.outputs.setup_docker }}
-  setup_services:
-    description: "Whether service containers started (true/false)"
-    value: ${{ steps.config.outputs.setup_services }}
+  service_redis:
+    description: "Whether redis-server was installed onto PATH (true/false)"
+    value: ${{ steps.config.outputs.service_redis }}
+  service_nats:
+    description: "Whether nats-server was installed onto PATH (true/false)"
+    value: ${{ steps.config.outputs.service_nats }}
   setup_system_packages:
     description: "Whether apt system_packages were installed (true/false)"
     value: ${{ steps.config.outputs.setup_system_packages }}
@@ -478,16 +481,14 @@ runs:
     # ══════════════════════════════════════════════════════════════════════════
     # 📦 SERVICES SETUP
     # ══════════════════════════════════════════════════════════════════════════
-    # 🧰 TEST BINARIES (external daemons installed on PATH)
+    # 🧰 SERVICES (external daemon binaries installed on PATH)
     # ══════════════════════════════════════════════════════════════════════════
-    # Distinct from the docker-based `services` block below. These are
-    # standalone daemon binaries (redis-server, nats-server, ...) installed
-    # directly onto the runner's PATH so tests can spawn them via
-    # `Command::new("<binary>")`. Used when tests manage server lifecycle
-    # themselves rather than connecting to a long-lived container.
+    # Daemons (redis-server, nats-server, …) placed directly on the runner's
+    # PATH so tests can spawn them themselves via `Command::new("<binary>")`.
+    # Tests own server lifecycle — we don't auto-start anything here.
 
     - name: Install redis-server
-      if: steps.config.outputs.test_binary_redis == 'true' && runner.os == 'Linux'
+      if: steps.config.outputs.service_redis == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
         echo "🧰 Installing redis-server via apt"
@@ -499,11 +500,11 @@ runs:
         redis-server --version
 
     - name: Install nats-server
-      if: steps.config.outputs.test_binary_nats == 'true' && runner.os == 'Linux'
+      if: steps.config.outputs.service_nats == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
         # nats-server isn't in apt; fetch the latest stable release binary.
-        # GitHub API redirects /latest to the most recent release tag.
+        # The /releases/latest URL redirects to the most recent tag.
         set -euo pipefail
         case "${{ runner.arch }}" in
           X64)   ASSET_ARCH="linux-amd64" ;;
@@ -525,136 +526,12 @@ runs:
         rm -rf "$TMP"
         nats-server --version
 
-    - name: Warn on non-Linux test_binaries request
-      if: (steps.config.outputs.test_binary_redis == 'true' || steps.config.outputs.test_binary_nats == 'true') && runner.os != 'Linux'
+    - name: Warn on non-Linux services request
+      if: (steps.config.outputs.service_redis == 'true' || steps.config.outputs.service_nats == 'true') && runner.os != 'Linux'
       shell: bash
       run: |
-        echo "::warning::test_binaries (redis/nats) currently install on Linux only; ignored on ${{ runner.os }}."
+        echo "::warning::services (redis/nats) currently install on Linux only; ignored on ${{ runner.os }}."
 
-    # ══════════════════════════════════════════════════════════════════════════
-    # 🐳 SERVICE CONTAINERS (docker-based daemons; distinct from test_binaries)
-    # ══════════════════════════════════════════════════════════════════════════
-    # Per-service credentials come from the calling workflow's env block:
-    #   POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB
-    #   REDIS_PASSWORD
-    #   MYSQL_ROOT_PASSWORD / MYSQL_DATABASE
-
-    - name: Start service containers
-      if: steps.config.outputs.setup_services == 'true'
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      env:
-        SERVICES_JSON: ${{ steps.config.outputs.services_json }}
-      run: |
-        echo "🚀 Starting service containers..."
-
-        # Parse services JSON and start each container
-        echo "$SERVICES_JSON" | jq -r 'to_entries[] | @base64' | while read -r service; do
-          # Decode service config
-          SERVICE_NAME=$(echo "$service" | base64 -d | jq -r '.key')
-          SERVICE_CONFIG=$(echo "$service" | base64 -d | jq -r '.value')
-
-          echo "  Starting $SERVICE_NAME..."
-
-          # Get image
-          IMAGE=$(echo "$SERVICE_CONFIG" | jq -r '.image // empty')
-          if [[ -z "$IMAGE" ]]; then
-            # Use service name as image with default tag
-            case "$SERVICE_NAME" in
-              postgres) IMAGE="postgres:16-alpine" ;;
-              redis) IMAGE="redis:7-alpine" ;;
-              nats) IMAGE="nats:2.10-alpine" ;;
-              mysql) IMAGE="mysql:8" ;;
-              mongo) IMAGE="mongo:7" ;;
-              *) IMAGE="$SERVICE_NAME:latest" ;;
-            esac
-          fi
-
-          # Get port
-          PORT=$(echo "$SERVICE_CONFIG" | jq -r '.port // empty')
-          PORT_ARG=""
-          if [[ -n "$PORT" ]]; then
-            PORT_ARG="-p $PORT:$PORT"
-          fi
-
-          # Get args
-          ARGS=$(echo "$SERVICE_CONFIG" | jq -r '.args // [] | join(" ")')
-
-          # Build environment variables
-          ENV_ARGS=""
-
-          # Service-specific env from config
-          ENV_CONFIG=$(echo "$SERVICE_CONFIG" | jq -r '.env // {} | to_entries[] | "-e \(.key)=\(.value)"' 2>/dev/null || echo "")
-          if [[ -n "$ENV_CONFIG" ]]; then
-            ENV_ARGS="$ENV_CONFIG"
-          fi
-
-          # Override with actual environment variables
-          case "$SERVICE_NAME" in
-            postgres)
-              [[ -n "${POSTGRES_USER:-}" ]] && ENV_ARGS="$ENV_ARGS -e POSTGRES_USER=$POSTGRES_USER"
-              [[ -n "${POSTGRES_PASSWORD:-}" ]] && ENV_ARGS="$ENV_ARGS -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD"
-              [[ -n "${POSTGRES_DB:-}" ]] && ENV_ARGS="$ENV_ARGS -e POSTGRES_DB=$POSTGRES_DB"
-              ;;
-            redis)
-              [[ -n "${REDIS_PASSWORD:-}" ]] && ENV_ARGS="$ENV_ARGS -e REDIS_PASSWORD=$REDIS_PASSWORD"
-              ;;
-            mysql)
-              [[ -n "${MYSQL_ROOT_PASSWORD:-}" ]] && ENV_ARGS="$ENV_ARGS -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD"
-              [[ -n "${MYSQL_DATABASE:-}" ]] && ENV_ARGS="$ENV_ARGS -e MYSQL_DATABASE=$MYSQL_DATABASE"
-              ;;
-          esac
-
-          # Get healthcheck
-          HEALTHCHECK=$(echo "$SERVICE_CONFIG" | jq -r '.healthcheck // empty')
-
-          # Start container
-          CONTAINER_NAME="test-$SERVICE_NAME"
-          docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-
-          # shellcheck disable=SC2086
-          docker run -d \
-            --name "$CONTAINER_NAME" \
-            $PORT_ARG \
-            $ENV_ARGS \
-            "$IMAGE" \
-            $ARGS
-
-          echo "    ✓ $SERVICE_NAME started (container: $CONTAINER_NAME)"
-        done
-
-        # Wait for services to be healthy
-        echo ""
-        echo "⏳ Waiting for services to be ready..."
-        sleep 5
-
-        # Service-specific health checks
-        SERVICE_NAMES="${{ steps.config.outputs.service_names }}"
-
-        if echo "$SERVICE_NAMES" | grep -q "postgres"; then
-          echo "  Checking PostgreSQL..."
-          for i in {1..30}; do
-            if docker exec test-postgres pg_isready -U "${POSTGRES_USER:-postgres}" >/dev/null 2>&1; then
-              echo "    ✓ PostgreSQL ready"
-              break
-            fi
-            sleep 1
-          done
-        fi
-
-        if echo "$SERVICE_NAMES" | grep -q "redis"; then
-          echo "  Checking Redis..."
-          for i in {1..30}; do
-            if docker exec test-redis redis-cli ping >/dev/null 2>&1; then
-              echo "    ✓ Redis ready"
-              break
-            fi
-            sleep 1
-          done
-        fi
-
-        echo ""
-        echo "✅ All services started"
 
     # ══════════════════════════════════════════════════════════════════════════
     # 📊 SUMMARY
@@ -688,8 +565,11 @@ runs:
           echo "| Docker | ✅ Configured |" >> $GITHUB_STEP_SUMMARY
         fi
 
-        if [[ "${{ steps.config.outputs.setup_services }}" == "true" ]]; then
-          echo "| Services | ✅ ${{ steps.config.outputs.service_names }} |" >> $GITHUB_STEP_SUMMARY
+        SERVICES=""
+        [[ "${{ steps.config.outputs.service_redis }}" == "true" ]] && SERVICES="${SERVICES}redis "
+        [[ "${{ steps.config.outputs.service_nats }}"  == "true" ]] && SERVICES="${SERVICES}nats "
+        if [[ -n "$SERVICES" ]]; then
+          echo "| Services | ✅ ${SERVICES% } |" >> $GITHUB_STEP_SUMMARY
         fi
 
         if [[ "${{ steps.config.outputs.setup_system_packages }}" == "true" ]]; then

--- a/actions/environment-setup/schema.json
+++ b/actions/environment-setup/schema.json
@@ -173,51 +173,18 @@
       ]
     },
 
-    "test_binaries": {
+    "services": {
       "type": "object",
-      "description": "Install external daemon binaries onto the runner's PATH so tests can spawn them as subprocesses. Distinct from `services` (which runs containerized daemons). Each key toggles a specific binary.",
+      "description": "External daemons installed onto the runner's PATH so tests can spawn them as subprocesses (via Command::new(\"redis-server\") etc.). Each key toggles a specific service binary. Linux runners only for now.",
       "additionalProperties": false,
       "properties": {
         "redis": {
           "type": "boolean",
-          "description": "Install `redis-server` via apt (Linux only). Tests typically spawn it via `Command::new(\"redis-server\")`."
+          "description": "Install `redis-server` via apt. Auto-start disabled — tests control lifecycle."
         },
         "nats": {
           "type": "boolean",
-          "description": "Install `nats-server` by downloading the latest stable release from github.com/nats-io/nats-server. Tests typically spawn it via `Command::new(\"nats-server\")`. Linux runners only for now."
-        }
-      }
-    },
-
-    "services": {
-      "type": "object",
-      "description": "Service containers to start on the runner. Keys are user-chosen names (postgres, redis, nats, ...). Auth env vars (POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, REDIS_PASSWORD, MYSQL_*) come from the calling workflow's env block.",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "image": {
-            "type": "string",
-            "description": "Container image (tag included). Defaults to a per-service sensible image if omitted."
-          },
-          "port": {
-            "type": ["integer", "string"],
-            "description": "Port to publish. Mapped 1:1 (host:container)."
-          },
-          "env": {
-            "type": "object",
-            "description": "Key/value env vars passed via -e.",
-            "additionalProperties": { "type": ["string", "number", "boolean"] }
-          },
-          "args": {
-            "type": "array",
-            "items": { "type": "string" },
-            "description": "Extra positional args appended to `docker run`."
-          },
-          "healthcheck": {
-            "type": "string",
-            "description": "Optional healthcheck command. Currently informational."
-          }
+          "description": "Install `nats-server` by downloading the latest stable release from github.com/nats-io/nats-server."
         }
       }
     },

--- a/actions/environment-setup/scripts/parse-config.sh
+++ b/actions/environment-setup/scripts/parse-config.sh
@@ -84,11 +84,12 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
     out "setup_python=false"
     out "setup_terraform=false"
     out "setup_docker=false"
-    out "setup_services=false"
     out "setup_system_packages=false"
     out "setup_rust=false"
     out "setup_go=false"
     out "setup_c=false"
+    out "service_redis=false"
+    out "service_nats=false"
     exit 0
 fi
 
@@ -338,40 +339,17 @@ else
 fi
 
 # ------------------------------------------------------------------------------
-# Services
+# services — external daemon binaries installed on PATH so tests can spawn
+# them as subprocesses. (Previously split into a docker-container `services`
+# block + a `test_binaries` block; unified here because nobody was using the
+# container variant and the split confused consumers.)
 # ------------------------------------------------------------------------------
-SERVICES_CONFIG=$(yq_get '.services // {}' "{}")
-
-if [[ "$SERVICES_CONFIG" != "{}" ]] && should_setup "services"; then
-    out "setup_services=true"
-
-    SERVICE_NAMES=$(yq_get '.services | keys | join(",")' "")
-    out "service_names=$SERVICE_NAMES"
-
-    # Emit services JSON as a multi-line output.
-    SERVICES_JSON=$(yq -e '.services' -o=json "$CONFIG_FILE" 2>/dev/null || printf '{}')
-    {
-        printf 'services_json<<EOF\n'
-        printf '%s\n' "$SERVICES_JSON"
-        printf 'EOF\n'
-    } >>"$GITHUB_OUTPUT"
-
-    echo "  ✓ Services: $SERVICE_NAMES"
-else
-    out "setup_services=false"
-    out "service_names="
-fi
-
-# ------------------------------------------------------------------------------
-# test_binaries — external daemons installed on PATH for tests that spawn them
-# as subprocesses (distinct from the docker-based `services` block above).
-# ------------------------------------------------------------------------------
-TB_REDIS=$(yq_get '.test_binaries.redis' "false")
-TB_NATS=$(yq_get '.test_binaries.nats' "false")
-out "test_binary_redis=$TB_REDIS"
-out "test_binary_nats=$TB_NATS"
-if [[ "$TB_REDIS" == "true" || "$TB_NATS" == "true" ]]; then
-    echo "  ✓ Test binaries: redis=$TB_REDIS, nats=$TB_NATS"
+SVC_REDIS=$(yq_get '.services.redis' "false")
+SVC_NATS=$(yq_get '.services.nats' "false")
+out "service_redis=$SVC_REDIS"
+out "service_nats=$SVC_NATS"
+if [[ "$SVC_REDIS" == "true" || "$SVC_NATS" == "true" ]]; then
+    echo "  ✓ Services: redis=$SVC_REDIS, nats=$SVC_NATS"
 fi
 
 echo "✅ Configuration parsed successfully"


### PR DESCRIPTION
## Why

The container-based `services` block (docker run of postgres/redis/nats/mysql/mongo) had zero consumers. Meanwhile v1.4.0 added `test_binaries` for the binary-install pattern that's actually used. Two overlapping blocks, one used, one dead — delete the dead one and reclaim the natural name for the live one.

## What the new `services` looks like

```yaml
services:
  redis: true
  nats:  true
```

Boolean-keyed. Means "install this daemon binary on PATH so tests can spawn it". No containers, no env plumbing, no healthcheck plumbing — tests control the lifecycle.

## Breaking change

Any external consumer that had `services:` set to the old container shape stops working. `mcpg-dev/source-code` doesn't use it; I'll bump the consumer PR (#22 in mcpg-dev) to use `services:` instead of `test_binaries:` right after this tags v1.5.0.

## Self-test

Polyglot fixtures don't use `services`, so no fixture migration. The skip-all test removed `services` from its skip list (field is gated per-key now). Assertion checking `setup_services=false` replaced with `service_redis=false` / `service_nats=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)