### PR TITLE
fix(env-setup): connectivity smoke tolerates 4xx from anti-bot gates

### DIFF
--- a/actions/environment-setup/action.yml
+++ b/actions/environment-setup/action.yml
@@ -390,9 +390,19 @@ runs:
         # -o /dev/null: throw away body, only report status
         # --write-out: print status code
         # --max-time: hard 5s cap
-        # -f (fail on non-2xx) so a 403 surfaces as a real error at step level.
-        for host in https://crates.io/ https://static.rust-lang.org/ https://github.com/; do
-          CODE=$(curl -fsS -o /dev/null --max-time 5 -w "%{http_code}" "$host")
+        # NOTE: we do NOT pass `-f` — the point of this probe is to
+        # confirm DNS + TCP + TLS work, not to assert the endpoint
+        # returns 2xx to anonymous traffic. Some of these hosts
+        # (github.com/, crates.io/) return 403/429 to unauthenticated
+        # curl under anti-bot rules; that still proves connectivity.
+        # A real network break surfaces as `--max-time` timeout or a
+        # non-zero curl exit code for transport errors, which we let
+        # through without `-f`.
+        for host in \
+            https://index.crates.io/config.json \
+            https://static.rust-lang.org/dist/channel-rust-stable.toml \
+            https://api.github.com/zen; do
+          CODE=$(curl -sS -o /dev/null --max-time 5 -w "%{http_code}" "$host" || echo "ERR")
           echo "  $host → HTTP $CODE"
         done
         if [[ -f Cargo.toml ]]; then


### PR DESCRIPTION
## Summary

The Rust-diagnostics connectivity smoke test used `curl -fsS`, which exits non-zero on HTTP 4xx. When github.com/ (or occasionally crates.io/) returned 403 to anonymous curl under anti-bot rules, the step exited 22 and flagged a yellow X on every CI job summary.

## What changed

- Drop `-f` and tolerate curl transport errors via `|| echo ERR`. A real connectivity outage surfaces as \`--max-time\` timeout (code \"000\") or the explicit \"ERR\" sentinel, not a 4xx response.
- Swap probed paths to endpoints that consistently return 200 to anonymous clients:
  - \`crates.io/\` → \`index.crates.io/config.json\` (sparse-index config)
  - \`static.rust-lang.org/\` → \`.../dist/channel-rust-stable.toml\`
  - \`github.com/\` → \`api.github.com/zen\`

## Why it's cosmetic (but worth fixing)

The step is \`continue-on-error: true\`, so CI never failed — but every run carried a misleading yellow X. Downstream consumers reading the summary had to triple-check whether they were actually offline or just hitting a GitHub anti-bot page. Now the probe genuinely measures connectivity.

## Test plan

- [ ] CI passes on this PR (the smoke-test step now reports \`HTTP 200\` for all three hosts on a healthy runner).
- [ ] A follow-up run on a downstream consumer (mcpg-dev/source-code#28) no longer shows a yellow X on the diagnostics step.