### PR TITLE
feat(nx-ci): add test_integration input + grant PROCESS to MySQL test user

### DIFF
--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -124,6 +124,24 @@ on:
         type: boolean
         default: false
 
+      test_integration:
+        description: |
+          Run the `test:integration` Nx target on projects that define it.
+          Intended for CD-gated lanes (merges / PRs targeting main / develop
+          / next) where integration suites against real databases, services,
+          and other heavy fixtures should run. Feature-branch PRs typically
+          keep this off so daily iteration stays fast.
+
+          Projects without a `test:integration` target are skipped silently
+          (nx reports the target is missing and moves on).
+
+          Services that integration suites depend on (postgres, mysql,
+          redis, nats, etc.) must be enabled via `environment_skip` /
+          `.environment.yml` — this input only runs the target.
+        required: false
+        type: boolean
+        default: false
+
       custom_tasks:
         description: |
           Additional custom tasks to run (comma-separated).
@@ -443,6 +461,39 @@ jobs:
           # `coverage` input on this workflow only gates whether we *upload*
           # those lcov artifacts downstream, not which target we run.
           CMD="$CMD -t test --parallel=${{ inputs.parallel }}"
+
+          if [ -n "${{ inputs.exclude_projects }}" ]; then
+            CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
+          fi
+
+          if [ "${{ inputs.verbose }}" == "true" ]; then
+            CMD="$CMD --verbose"
+          fi
+
+          echo "Running: $CMD"
+          $CMD
+
+      # ════════════════════════════════════════════════════════════════════════
+      # 🧪 TEST:INTEGRATION (OPTIONAL, CD-GATED)
+      # ════════════════════════════════════════════════════════════════════════
+
+      - name: Run test:integration
+        id: test_integration
+        if: inputs.test_integration
+        run: |
+          echo "🧪 Running test:integration..."
+          CMD="pnpm nx"
+
+          if [ "${{ inputs.affected_only }}" == "true" ]; then
+            CMD="$CMD affected"
+          else
+            CMD="$CMD run-many"
+          fi
+
+          # Projects without a `test:integration` target are skipped by Nx,
+          # so `run-many -t test:integration` is safe to run across every
+          # project even when only a subset declares the target.
+          CMD="$CMD -t test:integration --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"

--- a/actions/environment-setup/action.yml
+++ b/actions/environment-setup/action.yml
@@ -623,6 +623,12 @@ runs:
           CREATE DATABASE IF NOT EXISTS mcpg_test;
           GRANT ALL PRIVILEGES ON mcpg_test.* TO 'mcpg'@'127.0.0.1';
           GRANT ALL PRIVILEGES ON mcpg_test.* TO 'mcpg'@'localhost';
+          -- PROCESS is a server-wide privilege; required so cancellation
+          -- paths in SQL-binding integration tests can `KILL QUERY` their
+          -- own sessions (MySQL 8 rejects KILL without PROCESS). Safe to
+          -- grant on an ephemeral CI DB that only the test user touches.
+          GRANT PROCESS ON *.* TO 'mcpg'@'127.0.0.1';
+          GRANT PROCESS ON *.* TO 'mcpg'@'localhost';
           FLUSH PRIVILEGES;
         SQL
         echo "MYSQL_TEST_URL=mysql://mcpg:mcpg@127.0.0.1/mcpg_test" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
Two related changes that let workspaces move per-plugin integration workflows (mcpg-dev/source-code's \`sql-integration.yml\` is the motivating example) back onto nx-ci.yml alongside lint/test/build — gated on CD branches where integration suites should run.

### 1. \`nx-ci.yml\`: \`test_integration: bool\` input
- Default \`false\`. When \`true\`, runs \`pnpm nx <affected|run-many> -t test:integration\` after the \`test\` step.
- Projects without a \`test:integration\` target are skipped by Nx — safe to run across mixed workspaces.
- Caller gates it on the branch condition it cares about (push to main/develop/next, PR base in that set, etc.).
- Services the integration suites need stay gated via existing \`environment_skip\` / \`.environment.yml\` inputs.

### 2. \`environment-setup\`: grant \`PROCESS\` on *.* to \`mcpg\` MySQL user
MySQL 8 requires the server-wide \`PROCESS\` privilege for \`KILL QUERY\` across sessions. mcpg-dev's sql-binding cancellation tests exercise exactly that path. Grant is scoped to the same \`mcpg\`@\`127.0.0.1\` / \`mcpg\`@\`localhost\` users we already create for the test DB.

## Downstream impact
- Nothing breaks: \`test_integration\` defaults off; PROCESS grant is additive to an already-created test user.
- Once this ships (bump to \`v1.8.0\`), mcpg-dev can:
  - Set \`test_integration: \${{ condition }}\` in its continuous-integration caller.
  - Delete \`sql-integration.yml\` and the plugin-level PROCESS-grant shell step.

## Test plan
- [ ] CI on this PR passes.
- [ ] After merge, tag \`v1.8.0\` so the \`@v1\` alias picks up the new input.
- [ ] mcpg-dev/source-code caller flip + sql-integration.yml deletion PR succeeds end-to-end.