### PR TITLE
feat!(nx-ci,nx-cd): v2 — integration rename + cosign/SBOM/provenance

### DIFF
--- a/.github/workflows/nx-cd.yml
+++ b/.github/workflows/nx-cd.yml
@@ -234,14 +234,13 @@ on:
       # ─────────────────────────────────────────────────────────────────────────
       runs_on:
         description: |
-          Runner selector — a single label. Two conventions are recognised:
-            • a GitHub-hosted runner name (`ubuntu-*`, `macos-*`, `windows-*`)
-              is used as-is.
-            • anything else is treated as a self-hosted label and the implicit
-              `self-hosted` label is added, so `lab-large-runners` resolves to
-              `[self-hosted, lab-large-runners]`.
-          Multi-label self-hosted selectors (e.g. `[self-hosted, linux, gpu]`)
-          aren't expressible with this scheme — extend the input if needed.
+          Runner label passed straight to `runs-on`. Any runner that
+          advertises this label can pick up the job — for self-hosted
+          runners that's the label you set in `config.sh --labels …`
+          (the agent always advertises `self-hosted` alongside it, so
+          a single custom label is enough to disambiguate). For
+          GitHub-hosted runners, use the usual names (`ubuntu-latest`,
+          `macos-14`, `windows-2022`, …).
         required: false
         type: string
         default: "ubuntu-latest"
@@ -303,7 +302,7 @@ env:
 jobs:
   release:
     name: Version, Changelog, Publish
-    runs-on: ${{ (startsWith(inputs.runs_on, 'ubuntu-') || startsWith(inputs.runs_on, 'macos-') || startsWith(inputs.runs_on, 'windows-')) && inputs.runs_on || fromJSON(format('["self-hosted","{0}"]', inputs.runs_on)) }}
+    runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     outputs:

--- a/.github/workflows/nx-cd.yml
+++ b/.github/workflows/nx-cd.yml
@@ -147,6 +147,45 @@ on:
         default: "linux/amd64"
 
       # ─────────────────────────────────────────────────────────────────────────
+      # Supply-chain (cosign / SBOM / SLSA provenance) — v2
+      # ─────────────────────────────────────────────────────────────────────────
+      # These flags toggle env / tool installation that a project's `publish`
+      # target (or whichever target nx release invokes) consumes. The
+      # cryptographic operations themselves run inside the project's publish
+      # script — the reusable workflow only sets up tooling + permissions.
+      #
+      # Caller responsibility: when `cosign_sign: true`, the caller MUST grant
+      # `permissions.id-token: write` so cosign keyless can mint a Fulcio cert
+      # bound to the workflow's OIDC token.
+      cosign_sign:
+        description: |
+          Install cosign on PATH and export COSIGN_EXPERIMENTAL=1 so the
+          project's publish target can sign each published OCI artifact with
+          keyless signing (GitHub OIDC -> Fulcio -> Rekor).
+          Caller must grant `permissions.id-token: write`.
+        required: false
+        type: boolean
+        default: false
+
+      sbom_attach:
+        description: |
+          Install syft on PATH so the project's publish target can generate
+          an SBOM and attach it as an OCI referrer (typically via
+          `cosign attach sbom`).
+        required: false
+        type: boolean
+        default: false
+
+      docker_provenance:
+        description: |
+          Export DOCKER_PROVENANCE=mode=max to the publish target's environment
+          so it can pass `--provenance=mode=max` to `docker buildx build`,
+          emitting a SLSA-style provenance attestation.
+        required: false
+        type: boolean
+        default: false
+
+      # ─────────────────────────────────────────────────────────────────────────
       # Release Configuration
       # ─────────────────────────────────────────────────────────────────────────
       dry_run:
@@ -361,6 +400,37 @@ jobs:
           registry: ${{ inputs.docker_registry }}
           username: ${{ secrets.docker_username || github.actor }}
           password: ${{ secrets.docker_password || github.token }}
+
+      # ════════════════════════════════════════════════════════════════════════
+      # 🔐 SUPPLY-CHAIN TOOLING (CONDITIONAL)
+      # ════════════════════════════════════════════════════════════════════════
+      # cosign + syft are project-target dependencies, not workflow steps:
+      # we install them so the project's `publish` target can invoke them.
+
+      - name: Install cosign (keyless signing)
+        if: inputs.cosign_sign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Install syft (SBOM generator)
+        if: inputs.sbom_attach
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Export supply-chain env for publish targets
+        if: inputs.publish_docker
+        run: |
+          {
+            echo "COSIGN_SIGN=${{ inputs.cosign_sign }}"
+            echo "SBOM_ATTACH=${{ inputs.sbom_attach }}"
+            if [ "${{ inputs.docker_provenance }}" == "true" ]; then
+              echo "DOCKER_PROVENANCE=mode=max"
+            fi
+            if [ "${{ inputs.cosign_sign }}" == "true" ]; then
+              echo "COSIGN_EXPERIMENTAL=1"
+              echo "COSIGN_YES=true"
+            fi
+          } >> "$GITHUB_ENV"
 
       # ════════════════════════════════════════════════════════════════════════
       # 🚀 NX RELEASE

--- a/.github/workflows/nx-cd.yml
+++ b/.github/workflows/nx-cd.yml
@@ -234,8 +234,14 @@ on:
       # ─────────────────────────────────────────────────────────────────────────
       runs_on:
         description: |
-          Runner to use for the job.
-          Example: "ubuntu-latest", "self-hosted", '["self-hosted", "linux"]'
+          Runner selector — a single label. Two conventions are recognised:
+            • a GitHub-hosted runner name (`ubuntu-*`, `macos-*`, `windows-*`)
+              is used as-is.
+            • anything else is treated as a self-hosted label and the implicit
+              `self-hosted` label is added, so `lab-large-runners` resolves to
+              `[self-hosted, lab-large-runners]`.
+          Multi-label self-hosted selectors (e.g. `[self-hosted, linux, gpu]`)
+          aren't expressible with this scheme — extend the input if needed.
         required: false
         type: string
         default: "ubuntu-latest"
@@ -297,7 +303,7 @@ env:
 jobs:
   release:
     name: Version, Changelog, Publish
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (startsWith(inputs.runs_on, 'ubuntu-') || startsWith(inputs.runs_on, 'macos-') || startsWith(inputs.runs_on, 'windows-')) && inputs.runs_on || fromJSON(format('["self-hosted","{0}"]', inputs.runs_on)) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     outputs:

--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -248,14 +248,13 @@ on:
       # ─────────────────────────────────────────────────────────────────────────
       runs_on:
         description: |
-          Runner selector — a single label. Two conventions are recognised:
-            • a GitHub-hosted runner name (`ubuntu-*`, `macos-*`, `windows-*`)
-              is used as-is.
-            • anything else is treated as a self-hosted label and the implicit
-              `self-hosted` label is added, so `lab-large-runners` resolves to
-              `[self-hosted, lab-large-runners]`.
-          Multi-label self-hosted selectors (e.g. `[self-hosted, linux, gpu]`)
-          aren't expressible with this scheme — extend the input if needed.
+          Runner label passed straight to `runs-on`. Any runner that
+          advertises this label can pick up the job — for self-hosted
+          runners that's the label you set in `config.sh --labels …`
+          (the agent always advertises `self-hosted` alongside it, so
+          a single custom label is enough to disambiguate). For
+          GitHub-hosted runners, use the usual names (`ubuntu-latest`,
+          `macos-14`, `windows-2022`, …).
         required: false
         type: string
         default: "ubuntu-latest"
@@ -347,7 +346,7 @@ env:
 jobs:
   ci:
     name: Lint, Test, Build
-    runs-on: ${{ (startsWith(inputs.runs_on, 'ubuntu-') || startsWith(inputs.runs_on, 'macos-') || startsWith(inputs.runs_on, 'windows-')) && inputs.runs_on || fromJSON(format('["self-hosted","{0}"]', inputs.runs_on)) }}
+    runs-on: ${{ inputs.runs_on }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     outputs:

--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -248,8 +248,14 @@ on:
       # ─────────────────────────────────────────────────────────────────────────
       runs_on:
         description: |
-          Runner to use for the job.
-          Example: "ubuntu-latest", "self-hosted", '["self-hosted", "linux"]'
+          Runner selector — a single label. Two conventions are recognised:
+            • a GitHub-hosted runner name (`ubuntu-*`, `macos-*`, `windows-*`)
+              is used as-is.
+            • anything else is treated as a self-hosted label and the implicit
+              `self-hosted` label is added, so `lab-large-runners` resolves to
+              `[self-hosted, lab-large-runners]`.
+          Multi-label self-hosted selectors (e.g. `[self-hosted, linux, gpu]`)
+          aren't expressible with this scheme — extend the input if needed.
         required: false
         type: string
         default: "ubuntu-latest"
@@ -341,7 +347,7 @@ env:
 jobs:
   ci:
     name: Lint, Test, Build
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (startsWith(inputs.runs_on, 'ubuntu-') || startsWith(inputs.runs_on, 'macos-') || startsWith(inputs.runs_on, 'windows-')) && inputs.runs_on || fromJSON(format('["self-hosted","{0}"]', inputs.runs_on)) }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
 
     outputs:

--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -124,20 +124,25 @@ on:
         type: boolean
         default: false
 
-      test_integration:
+      integration:
         description: |
-          Run the `test:integration` Nx target on projects that define it.
+          Run the `integration` Nx target on projects that define it.
           Intended for CD-gated lanes (merges / PRs targeting main / develop
           / next) where integration suites against real databases, services,
           and other heavy fixtures should run. Feature-branch PRs typically
           keep this off so daily iteration stays fast.
 
-          Projects without a `test:integration` target are skipped silently
+          Projects without an `integration` target are skipped silently
           (nx reports the target is missing and moves on).
 
           Services that integration suites depend on (postgres, mysql,
           redis, nats, etc.) must be enabled via `environment_skip` /
           `.environment.yml` — this input only runs the target.
+
+          **v2 rename:** this input was named `test_integration` in v1
+          and ran the `test:integration` target. Both renamed to the
+          unprefixed `integration` for naming uniformity with `lint`,
+          `test`, `build`, `e2e`.
         required: false
         type: boolean
         default: false
@@ -474,14 +479,14 @@ jobs:
           $CMD
 
       # ════════════════════════════════════════════════════════════════════════
-      # 🧪 TEST:INTEGRATION (OPTIONAL, CD-GATED)
+      # 🧪 INTEGRATION (OPTIONAL, CD-GATED)
       # ════════════════════════════════════════════════════════════════════════
 
-      - name: Run test:integration
-        id: test_integration
-        if: inputs.test_integration
+      - name: Run integration
+        id: integration
+        if: inputs.integration
         run: |
-          echo "🧪 Running test:integration..."
+          echo "🧪 Running integration..."
           CMD="pnpm nx"
 
           if [ "${{ inputs.affected_only }}" == "true" ]; then
@@ -490,10 +495,10 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          # Projects without a `test:integration` target are skipped by Nx,
-          # so `run-many -t test:integration` is safe to run across every
+          # Projects without an `integration` target are skipped by Nx,
+          # so `run-many -t integration` is safe to run across every
           # project even when only a subset declares the target.
-          CMD="$CMD -t test:integration --parallel=${{ inputs.parallel }}"
+          CMD="$CMD -t integration --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"


### PR DESCRIPTION
## Summary

v2.0.0 of the reusable Nx CI/CD workflows. Two threads:

### 1. Naming uniformity (breaking)

`test_integration` input → `integration`. The Nx target the step
invokes also renames from `test:integration` to `integration`.
Aligns with the existing `lint` / `test` / `build` / `e2e` inputs —
all single tokens, no colons.

Migration for consumers:
- `test_integration: true` → `integration: true` in the caller
- `\"test:integration\"` → `\"integration\"` in every project.json

### 2. Supply-chain primitives (additive)

Three opt-in inputs on \`nx-cd.yml\` that toggle env / tool setup so
the project's \`publish\` target can produce signed + attested OCI
artifacts:

| Input | Effect |
|---|---|
| \`cosign_sign: true\` | Install cosign on PATH; export \`COSIGN_EXPERIMENTAL=1\` + \`COSIGN_YES=true\`. Caller must grant \`permissions.id-token: write\` for keyless OIDC signing. |
| \`sbom_attach: true\` | Install syft on PATH. |
| \`docker_provenance: true\` | Export \`DOCKER_PROVENANCE=mode=max\` so the publish script can pass \`--provenance=mode=max\` to \`docker buildx build\`. |

The cryptographic operations themselves run inside the project's
\`publish\` target — the reusable workflow only sets up tooling.
This keeps the workflow surface project-agnostic: no
\`docker_publish_target\`, no \`docker_arch_matrix\`, no
\`docker_arch_runners\`. The project owns those concerns.

## Why v2 (and not v1.9 with deprecation)

The \`test_integration\` rename is strictly breaking. Could ship as
v1.9 alongside the old name, but the migration's blast radius (every
consumer's nx.json + project.json + caller) is large enough that a
major bump gives consumers a clean opt-in boundary. \`@v1\` stays
pointed at v1.8.0 for existing callers; new consumers pin \`@v2\`.

## Test plan

- [ ] Self-test workflow runs green on this PR
- [ ] Tag v2.0.0-rc.1 once green; mcpg consumes it
- [ ] Tag v2.0.0 stable; float \`@v2\` once mcpg validates
- [ ] Document migration in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)