### PR TITLE
feat: nx-ci@v5 language packs + nx-affected-plan@v5 gates

### DIFF
--- a/.github/workflows/nx-affected-plan.yml
+++ b/.github/workflows/nx-affected-plan.yml
@@ -99,6 +99,33 @@ on:
         type: number
         default: 10
 
+      # ─────────────────────────────────────────────────────────────────────────
+      # Gates (v5 addition)
+      # ─────────────────────────────────────────────────────────────────────────
+      # Evaluate boolean gates against the affected set without forcing the
+      # caller to spin up a separate "detect affected" job. Each gate is a
+      # `name=pattern` pair; the plan emits a JSON map of gate names to
+      # booleans. Consumers reference via:
+      #   `fromJSON(needs.plan.outputs.gates).has_sql == true`
+      gates:
+        description: |
+          Semicolon-separated `gate_name=pattern` pairs. Each pattern is
+          matched against the affected project set; if at least one
+          project matches, the gate's boolean is `true`. Patterns are
+          shell-glob style (`*`, `?`) — NOT regex.
+
+          Example:
+            gates: "has_sql=mcpg-plugin-backend-sql;has_cluster=mcpg-plugin-cluster-*;has_payment=mcpg-plugin-payment-*"
+
+          The plan emits a JSON map as the `gates` output, e.g.:
+            {"has_sql": true, "has_cluster": false, "has_payment": true}
+
+          Language-agnostic: gates are purely Nx project-graph queries.
+          Empty (default) skips the gate-evaluation step entirely.
+        required: false
+        type: string
+        default: ""
+
     secrets:
       # Self-hosted cache plumbing — declared so cross-org callers can pass
       # them explicitly. The plan job doesn't run heavy tasks but the
@@ -123,6 +150,14 @@ on:
       nx_head:
         description: "Head SHA computed by nrwl/nx-set-shas. Pass to every shard."
         value: ${{ jobs.plan.outputs.nx_head }}
+      gates:
+        description: |
+          JSON map of gate name → boolean evaluated against the affected
+          set. Emitted only when the `gates` input is non-empty;
+          otherwise `"{}"`. Consume via
+          `fromJSON(needs.plan.outputs.gates).has_sql`.
+        value: ${{ jobs.plan.outputs.gates }}
+
       has_shards:
         description: |
           "true" if at least one target has affected projects. Callers
@@ -160,6 +195,7 @@ jobs:
       nx_base: ${{ steps.set-shas.outputs.base }}
       nx_head: ${{ steps.set-shas.outputs.head }}
       has_shards: ${{ steps.plan.outputs.has_shards }}
+      gates: ${{ steps.gates.outputs.gates }}
 
     steps:
       - name: Checkout repository
@@ -326,5 +362,82 @@ jobs:
             echo ""
             echo '```json'
             echo "$matrix" | jq .
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ════════════════════════════════════════════════════════════════════════
+      # 🚦 EVALUATE GATES (v5 addition — opt-in)
+      # ════════════════════════════════════════════════════════════════════════
+      # For each `gate_name=pattern` pair in the `gates` input, run nx to
+      # check whether any project in the affected set matches the pattern.
+      # Emits a JSON map as the `gates` output. Skipped (emits `{}`) when
+      # the input is empty.
+      #
+      # Patterns are shell-glob style. The Nx CLI accepts these directly via
+      # `nx show projects --affected -p '<glob>' --json`. We use `nx show`
+      # rather than re-querying jq against the matrix output so the gate
+      # evaluation honors the full affected detection semantics (including
+      # implicit deps, namedInputs, etc.).
+      - name: Evaluate gates
+        id: gates
+        # Always runs (even when `inputs.gates == ''`) so the workflow-level
+        # `gates` output is consistently `{...}` JSON. The empty-input
+        # branch fast-exits with `{}` after a single output write.
+        env:
+          NX_BASE: ${{ steps.set-shas.outputs.base }}
+          NX_HEAD: ${{ steps.set-shas.outputs.head }}
+          GATES_CSV: ${{ inputs.gates }}
+          PKG_MGR: ${{ steps.pkg.outputs.manager }}
+        run: |
+          set -euo pipefail
+          if [ -z "$GATES_CSV" ]; then
+            echo "gates={}" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  No gates configured — emitting empty map."
+            exit 0
+          fi
+
+          case "$PKG_MGR" in
+            bun)   NX_CMD="bun nx" ;;
+            pnpm)  NX_CMD="pnpm nx" ;;
+            yarn)  NX_CMD="yarn nx" ;;
+            npm)   NX_CMD="npm exec nx --" ;;
+            *)     NX_CMD="npx nx" ;;
+          esac
+
+          gates_map='{}'
+          IFS=';' read -ra PAIRS <<< "$GATES_CSV"
+          for pair in "${PAIRS[@]}"; do
+            pair="$(echo "$pair" | xargs)"
+            [ -z "$pair" ] && continue
+
+            name="${pair%%=*}"
+            pattern="${pair#*=}"
+            if [ -z "$name" ] || [ -z "$pattern" ] || [ "$name" = "$pair" ]; then
+              echo "::warning::Malformed gate entry '$pair' — expected name=pattern. Skipping."
+              continue
+            fi
+
+            # Query nx with the glob pattern. Output: JSON array of
+            # matching affected project names. Non-empty array = true.
+            matches=$($NX_CMD show projects --affected --base="$NX_BASE" --head="$NX_HEAD" -p "$pattern" --json 2>/dev/null || echo '[]')
+            count=$(echo "$matches" | jq 'length')
+
+            if [ "$count" -gt 0 ]; then
+              value=true
+              echo "✅ gate $name=$pattern → true ($count affected project(s))"
+            else
+              value=false
+              echo "⬜ gate $name=$pattern → false"
+            fi
+            gates_map=$(echo "$gates_map" | jq -c --arg name "$name" --argjson v "$value" '. + {($name): $v}')
+          done
+
+          echo "gates=$gates_map" >> "$GITHUB_OUTPUT"
+          {
+            echo ""
+            echo "### 🚦 Gates"
+            echo ""
+            echo '```json'
+            echo "$gates_map" | jq .
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nx-ci.yml
+++ b/.github/workflows/nx-ci.yml
@@ -390,6 +390,101 @@ on:
         type: string
         default: ""
 
+      # ─────────────────────────────────────────────────────────────────────────
+      # Language packs (v5 addition)
+      # ─────────────────────────────────────────────────────────────────────────
+      # The workflow body is language-agnostic — it only invokes Nx. Anything
+      # language-specific (CARGO_TARGET_DIR scoping, env validation, cache
+      # gating, etc.) lives in a composite action that this workflow invokes
+      # when the corresponding pack is listed in `language_packs`. Supported
+      # packs ship in tsok-org/.github/actions/nx-<lang>-setup. Add a new
+      # language by adding a new composite — NOT by editing this workflow.
+      #
+      # Currently supported:
+      #   - rust       → actions/nx-rust-setup
+      #
+      # Always-on (no opt-in needed):
+      #   - workspace  → actions/nx-workspace-setup (pnpm/yarn/npm install).
+      #                  Mandatory in container mode because nx itself is a
+      #                  Node package, regardless of app-code language.
+      #
+      # Future:
+      #   - go, python, c — add the composite + a new `if: contains(...)`
+      #     branch alongside the existing rust step.
+      language_packs:
+        description: |
+          Comma-separated language packs to enable in CONTAINER MODE. Each
+          pack invokes the matching tsok-org composite action before the
+          nx target runs. Ignored when `container_image` is empty (host
+          mode delegates to actions/environment-setup via .environment.yml).
+
+          Supported: rust.
+          Reserved-for-future: go, python, c, java.
+
+          Example: language_packs: "rust"
+        required: false
+        type: string
+        default: ""
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # Nx target configuration suffix (v5 addition)
+      # ─────────────────────────────────────────────────────────────────────────
+      # Nx supports per-target configurations: `nx run myproj:test:pg17`.
+      # Pass the suffix here (without the leading colon) and the workflow
+      # appends it to the target name when invoking nx. Mutually compatible
+      # with the existing single-shard `target` + `projects` inputs.
+      target_configuration:
+        description: |
+          Nx target configuration suffix (without leading colon). When set,
+          the nx invocation becomes `nx run-many -t <target>:<configuration>
+          -p <projects>`. Useful for parameterised test matrices (e.g.
+          per-DB-engine configurations on the SQL backend plugin).
+
+          Default empty = no configuration suffix.
+        required: false
+        type: string
+        default: ""
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # Extra env vars (v5 addition)
+      # ─────────────────────────────────────────────────────────────────────────
+      # Lets callers pass arbitrary env vars without modifying the reusable
+      # workflow. JSON object of {name: value}; each entry is exported to
+      # GITHUB_ENV before the language packs run. Use for matrix-row
+      # parameterisation (e.g. POSTGRES_TEST_URL per row) or secret
+      # injection (when paired with explicit secrets).
+      extra_env_json:
+        description: |
+          JSON object of additional env vars to export to GITHUB_ENV.
+          Example:
+            extra_env_json: |
+              {"POSTGRES_TEST_URL": "postgres://u:p@postgres:5432/db",
+               "RUSTFLAGS": "-C link-arg=-fuse-ld=lld"}
+
+          Default: empty object (no extras).
+        required: false
+        type: string
+        default: "{}"
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # Cache mode override (v5 addition)
+      # ─────────────────────────────────────────────────────────────────────────
+      # The workflow auto-computes NX_POWERPACK_CACHE_MODE from the trigger
+      # (CREEP CVE-2025-36852 mitigation: PR runs are read-only, trusted refs
+      # are read-write). Callers with non-standard threat models can override.
+      nx_powerpack_cache_mode:
+        description: |
+          Override the auto-computed @nx/s3-cache mode. Default empty =
+          auto: read-only for `pull_request`, read-write for push/schedule/
+          workflow_dispatch. Valid explicit values: `read-only`, `read-write`,
+          `no-cache`.
+
+          Use to force read-only on workflow_dispatch from feature branches,
+          or to disable cache entirely for forensic re-runs.
+        required: false
+        type: string
+        default: ""
+
     secrets:
       nx_cloud_access_token:
         description: "Nx Cloud access token for remote caching"
@@ -471,11 +566,17 @@ env:
   # like an if/else.
   #
   # https://nx.dev/blog/cve-2025-36852-critical-cache-poisoning-vulnerability-creep
+  # v5: callers can override via `nx_powerpack_cache_mode` input. Default
+  # behavior (empty input) preserves the v4 auto-compute logic.
   NX_POWERPACK_CACHE_MODE: >-
     ${{
-      (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        && 'read-write'
-        || 'read-only'
+      inputs.nx_powerpack_cache_mode != ''
+        && inputs.nx_powerpack_cache_mode
+        || (
+          (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+            && 'read-write'
+            || 'read-only'
+        )
     }}
   # NX_CLOUD_ACCESS_TOKEN is intentionally NOT declared at workflow
   # level. Declaring it here evaluates `secrets.nx_cloud_access_token`
@@ -628,55 +729,53 @@ jobs:
           only: ${{ inputs.environment_only }}
           container_image: ${{ inputs.container_image }}
 
-      # ── Container mode: image bakes runtimes + tooling. Inline the few
-      # bits that the composite still does for host-mode callers (rust
-      # cache, linker flag, env-var sanity), then run pnpm install.
-      # No .environment.yml needed.
-      - name: Validate CI env vars (container mode)
-        if: inputs.container_image != ''
+      # ── Container mode (v5): export caller-provided env vars first so
+      # language packs and downstream nx commands see them. Empty
+      # `extra_env_json: "{}"` is a no-op.
+      - name: Apply extra env vars (container mode)
+        if: inputs.container_image != '' && inputs.extra_env_json != '' && inputs.extra_env_json != '{}'
         shell: bash
+        env:
+          EXTRA_ENV_JSON: ${{ inputs.extra_env_json }}
         run: |
-          # Same checks the env-setup composite runs on host: cargo hard-errors
-          # on empty CARGO_TERM_* / RUST_BACKTRACE strings. Catch caller
-          # miswiring before cargo sees it.
-          fail=0
-          check_enum() {
-            local name="$1"; shift
-            local value="${!name-__unset__}"
-            if [[ "$value" == "__unset__" ]]; then return 0; fi
-            for allowed in "$@"; do
-              if [[ "$value" == "$allowed" ]]; then return 0; fi
-            done
-            echo "::error::Invalid $name=\"$value\". Expected one of: $*"
-            fail=1
-          }
-          check_enum CARGO_TERM_VERBOSE "true" "false"
-          check_enum CARGO_TERM_COLOR "auto" "always" "never"
-          check_enum RUST_BACKTRACE "0" "1" "full"
-          if [[ "$fail" -ne 0 ]]; then
-            echo "Bad CI env vars will make cargo reject the invocation."
-            exit 1
-          fi
-          echo "✅ CI env vars valid."
+          set -euo pipefail
+          # Validate JSON shape early. jq returns non-zero on invalid input.
+          echo "$EXTRA_ENV_JSON" | jq -e 'type == "object"' >/dev/null \
+            || { echo "::error::extra_env_json must be a JSON object"; exit 1; }
+          # Iterate keys/values via jq, append name=value to $GITHUB_ENV.
+          while IFS=$'\t' read -r key value; do
+            echo "$key=$value" >> "$GITHUB_ENV"
+            echo "🌱 exported $key"
+          done < <(echo "$EXTRA_ENV_JSON" | jq -r 'to_entries[] | "\(.key)\t\(.value)"')
 
-      - name: Install workspace dependencies (container mode)
+      # ── Container mode: ALWAYS install Nx workspace deps (nx itself is
+      # a Node package, regardless of app-code language). Detects the
+      # package manager from lockfiles and runs the frozen-lockfile install.
+      - name: Workspace setup (container mode)
         if: inputs.container_image != ''
-        shell: bash
-        working-directory: ${{ inputs.working_directory }}
-        run: pnpm install --frozen-lockfile
-
-      # Swatinem/rust-cache only on GitHub-hosted runners. Self-hosted
-      # lab-runners have a persistent host-mounted working dir that
-      # survives across runs in container mode; rust-cache would
-      # actively fight that (cleans ~/.cargo/bin, partial-restores
-      # target tarballs over a dir the runner already has). See
-      # Swatinem/rust-cache#194 for the upstream acknowledgement.
-      - name: Cache cargo registry + target (container mode)
-        if: inputs.container_image != '' && runner.environment == 'github-hosted'
-        uses: Swatinem/rust-cache@v2
+        uses: tsok-org/.github/actions/nx-workspace-setup@main
         with:
-          save-if: true
-          shared-key: "rust-workspace"
+          working_directory: ${{ inputs.working_directory }}
+          frozen_lockfile: "true"
+
+      # ── Container mode: language-specific packs. Each pack is a thin
+      # composite that does its language's CI-glue extras (env validation,
+      # cache scoping, tool installs). NOT language toolchain install —
+      # that's the container image's responsibility.
+      - name: Rust language pack
+        if: inputs.container_image != '' && contains(format(',{0},', inputs.language_packs), ',rust,')
+        uses: tsok-org/.github/actions/nx-rust-setup@main
+        with:
+          target: ${{ inputs.target }}
+          shard: ${{ inputs.shard }}
+          shards_total: ${{ inputs.shards_total }}
+          container_image: ${{ inputs.container_image }}
+
+      # Add future language packs here. Each is a separate `uses:` step
+      # gated on `contains(format(',{0},', inputs.language_packs), ',<lang>,')`.
+      # Adding a pack does NOT require touching any other part of this
+      # workflow — only the composite at actions/nx-<lang>-setup/action.yml
+      # plus a step here.
 
       # NOTE: Rust linker selection is now baked per-repo via
       # `.cargo/config.toml` (callers commit their own per-target
@@ -703,18 +802,11 @@ jobs:
       # 📋 GET AFFECTED PROJECTS
       # ════════════════════════════════════════════════════════════════════════
 
-      # Per-shard CARGO_TARGET_DIR so concurrent shards on the same
-      # self-hosted runner don't fight over a single target dir. Only
-      # active in single-shard mode (otherwise we keep the runner-wide
-      # persistent target dir behavior).
-      - name: Scope CARGO_TARGET_DIR per shard
-        if: inputs.target != '' && inputs.shards_total > 1
-        shell: bash
-        run: |
-          DIR="/tmp/cargo-target-${{ inputs.target }}-${{ inputs.shard }}"
-          mkdir -p "$DIR"
-          echo "CARGO_TARGET_DIR=$DIR" >> "$GITHUB_ENV"
-          echo "🦀 CARGO_TARGET_DIR=$DIR (shard ${{ inputs.shard }}/${{ inputs.shards_total }})"
+      # NOTE: Per-shard CARGO_TARGET_DIR scoping moved to the Rust language
+      # pack composite (actions/nx-rust-setup). The composite runs in
+      # container mode only — host mode doesn't need shard scoping because
+      # the env-setup composite handles it via .environment.yml setup-rust
+      # block.
 
       - name: Get affected projects
         id: affected
@@ -760,7 +852,9 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          CMD="$CMD -t lint --parallel=${{ inputs.parallel }}"
+          # v5: append :<configuration> suffix iff target_configuration is set.
+          TARGET_SUFFIX="${{ inputs.target_configuration }}"
+          CMD="$CMD -t lint${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
@@ -814,7 +908,9 @@ jobs:
           # `cargo llvm-cov ...` produces lcov.info as a side effect); the
           # `coverage` input on this workflow only gates whether we *upload*
           # those lcov artifacts downstream, not which target we run.
-          CMD="$CMD -t test --parallel=${{ inputs.parallel }}"
+          # v5: append :<configuration> suffix iff target_configuration is set.
+          TARGET_SUFFIX="${{ inputs.target_configuration }}"
+          CMD="$CMD -t test${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
@@ -866,7 +962,10 @@ jobs:
           # Projects without an `integration` target are skipped by Nx,
           # so `run-many -t integration` is safe to run across every
           # project even when only a subset declares the target.
-          CMD="$CMD -t integration --parallel=${{ inputs.parallel }}"
+          # v5: append :<configuration> suffix iff target_configuration is set.
+          # This is the common case for per-DB-engine matrices (pg14/pg17 etc).
+          TARGET_SUFFIX="${{ inputs.target_configuration }}"
+          CMD="$CMD -t integration${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
@@ -951,7 +1050,9 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          CMD="$CMD -t build --parallel=${{ inputs.parallel }}"
+          # v5: append :<configuration> suffix iff target_configuration is set.
+          TARGET_SUFFIX="${{ inputs.target_configuration }}"
+          CMD="$CMD -t build${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
@@ -1000,7 +1101,9 @@ jobs:
             CMD="$CMD run-many"
           fi
 
-          CMD="$CMD -t e2e --parallel=${{ inputs.parallel }}"
+          # v5: append :<configuration> suffix iff target_configuration is set.
+          TARGET_SUFFIX="${{ inputs.target_configuration }}"
+          CMD="$CMD -t e2e${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
           if [ -n "${{ inputs.exclude_projects }}" ]; then
             CMD="$CMD --exclude=${{ inputs.exclude_projects }}"
@@ -1068,7 +1171,9 @@ jobs:
               CMD="$CMD run-many"
             fi
 
-            CMD="$CMD -t $TASK --parallel=${{ inputs.parallel }}"
+            # v5: append :<configuration> suffix iff target_configuration is set.
+            TARGET_SUFFIX="${{ inputs.target_configuration }}"
+            CMD="$CMD -t ${TASK}${TARGET_SUFFIX:+:$TARGET_SUFFIX} --parallel=${{ inputs.parallel }}"
 
             if [ -n "${{ inputs.exclude_projects }}" ]; then
               CMD="$CMD --exclude=${{ inputs.exclude_projects }}"

--- a/actions/nx-rust-setup/action.yml
+++ b/actions/nx-rust-setup/action.yml
@@ -1,0 +1,198 @@
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║                         NX RUST SETUP COMPOSITE ACTION                       ║
+# ╠══════════════════════════════════════════════════════════════════════════════╣
+# ║  Rust-specific container-mode runtime extras for Nx CI jobs. This action     ║
+# ║  is invoked by nx-ci.yml@v5 when `language_packs` includes 'rust'. It does   ║
+# ║  NOT install the Rust toolchain — that's the consumer container image's     ║
+# ║  responsibility (or environment-setup's job in host mode). This composite    ║
+# ║  is the Nx-CI-glue layer for Rust: env validation, per-shard target dir,    ║
+# ║  cache gating, optional cargo-nextest install.                               ║
+# ║                                                                              ║
+# ║  Why a composite (not inline in nx-ci.yml@v5):                              ║
+# ║    Keeps the reusable workflow language-agnostic. Adding Go / Python / C    ║
+# ║    packs in the future means adding new composites, NOT touching the         ║
+# ║    nx-ci.yml body. The workflow only knows about the `language_packs` CSV   ║
+# ║    and routes to the matching composite.                                    ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+#
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ WHAT THIS DOES                                                              │
+# ├─────────────────────────────────────────────────────────────────────────────┤
+# │ 1. Validate cargo env enums (CARGO_TERM_VERBOSE / CARGO_TERM_COLOR /        │
+# │    RUST_BACKTRACE). Cargo hard-errors on empty/invalid strings; this        │
+# │    catches caller miswiring before cargo sees it.                           │
+# │                                                                             │
+# │ 2. Scope CARGO_TARGET_DIR per shard. Concurrent shards on a single self-    │
+# │    hosted runner would otherwise corrupt each other's target/ tree. Only    │
+# │    activates in single-shard mode (target + shards_total > 1).              │
+# │                                                                             │
+# │ 3. Cache cargo registry + target (Swatinem/rust-cache). Gated on            │
+# │    runner.environment == 'github-hosted' — self-hosted runners typically    │
+# │    have a persistent host-mounted working dir where Swatinem fights with    │
+# │    on-disk state (Swatinem/rust-cache#194).                                 │
+# │                                                                             │
+# │ 4. Install cargo-nextest (optional). Most Nx-Rust workspaces use            │
+# │    `cargo nextest run` because nextest is 1.4-3.4× faster than cargo test.  │
+# │    Skip with `install_nextest: false` if your workspace uses cargo test.    │
+# └─────────────────────────────────────────────────────────────────────────────┘
+#
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ USAGE                                                                       │
+# ├─────────────────────────────────────────────────────────────────────────────┤
+# │ Usually invoked transitively via nx-ci.yml@v5 with `language_packs: rust`.  │
+# │ Direct usage:                                                               │
+# │                                                                             │
+# │   - uses: tsok-org/.github/actions/nx-rust-setup@v1                        │
+# │     with:                                                                   │
+# │       target: integration                                                   │
+# │       shard: ${{ matrix.shard }}                                            │
+# │       shards_total: ${{ matrix.shards_total }}                              │
+# │       container_image: ghcr.io/myorg/build-env:ci-latest                    │
+# │       install_nextest: true                                                 │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
+name: "Nx Rust Setup"
+description: |
+  Rust-specific container-mode runtime configuration for Nx CI: env
+  validation, per-shard CARGO_TARGET_DIR scoping, cache gating, and
+  optional cargo-nextest installation. Does NOT install the Rust
+  toolchain (that's the container image's job).
+
+inputs:
+  target:
+    description: |
+      Nx target being run in this job (e.g. `test`, `integration`,
+      `build:cdylib`). Used to scope CARGO_TARGET_DIR per target so
+      concurrent matrix rows on the same runner don't collide.
+    required: false
+    default: ""
+
+  shard:
+    description: |
+      1-based shard index (1..shards_total). Used together with `target`
+      to produce a unique CARGO_TARGET_DIR path per shard.
+    required: false
+    default: "0"
+
+  shards_total:
+    description: |
+      Total shard count. When > 1, CARGO_TARGET_DIR scoping activates.
+      When ≤ 1, the runner-wide target dir is preserved (faster cache
+      hits across single-shard runs).
+    required: false
+    default: "1"
+
+  container_image:
+    description: |
+      The job's container image reference, if any. Empty string = host
+      mode (skip cache step; environment-setup handles it). Non-empty =
+      container mode (enable Swatinem cache when runner is github-hosted).
+    required: false
+    default: ""
+
+  install_nextest:
+    description: |
+      Install cargo-nextest if not already on PATH. Most Nx-Rust
+      workspaces use nextest; set to false if you use plain `cargo test`.
+    required: false
+    default: "true"
+
+  nextest_version:
+    description: |
+      Version requirement for cargo-nextest. Honors cargo semver syntax
+      (e.g. `^0.9`, `=0.9.85`).
+    required: false
+    default: "^0.9"
+
+runs:
+  using: composite
+  steps:
+    # ─────────────────────────────────────────────────────────────────────────
+    # 1. Validate cargo env enums
+    # ─────────────────────────────────────────────────────────────────────────
+    # Cargo hard-errors on empty strings for CARGO_TERM_VERBOSE etc:
+    #   error in environment variable `CARGO_TERM_VERBOSE`: provided string
+    #   was not `true` or `false`
+    # Catch caller miswiring before cargo sees it. Only validates vars that
+    # are actually set (skips unset).
+    - name: Validate cargo env enums
+      shell: bash
+      run: |
+        fail=0
+        check_enum() {
+          local name="$1"; shift
+          local value="${!name-__unset__}"
+          if [[ "$value" == "__unset__" ]]; then return 0; fi
+          for allowed in "$@"; do
+            if [[ "$value" == "$allowed" ]]; then return 0; fi
+          done
+          echo "::error::Invalid $name=\"$value\". Expected one of: $*"
+          fail=1
+        }
+        check_enum CARGO_TERM_VERBOSE  "true" "false"
+        check_enum CARGO_TERM_COLOR    "auto" "always" "never"
+        check_enum RUST_BACKTRACE      "0" "1" "full"
+        if [[ "$fail" -ne 0 ]]; then
+          echo "Bad CI env vars will make cargo reject the invocation."
+          exit 1
+        fi
+        echo "✅ cargo env enums valid"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # 2. Per-shard CARGO_TARGET_DIR scoping
+    # ─────────────────────────────────────────────────────────────────────────
+    # When multiple matrix rows run concurrently on the same self-hosted
+    # runner with shards_total > 1, they otherwise all write to the same
+    # workspace target/ — interleaved writes corrupt each other's
+    # incrementals. Scope per (target, shard) to prevent that.
+    - name: Scope CARGO_TARGET_DIR per shard
+      if: inputs.target != '' && inputs.shards_total != '1' && inputs.shards_total != '0'
+      shell: bash
+      run: |
+        DIR="/tmp/cargo-target-${{ inputs.target }}-${{ inputs.shard }}"
+        mkdir -p "$DIR"
+        echo "CARGO_TARGET_DIR=$DIR" >> "$GITHUB_ENV"
+        echo "🦀 CARGO_TARGET_DIR=$DIR (shard ${{ inputs.shard }}/${{ inputs.shards_total }})"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # 3. Cache cargo registry + target (github-hosted only)
+    # ─────────────────────────────────────────────────────────────────────────
+    # Swatinem/rust-cache is great on ephemeral GH-hosted runners but
+    # actively harmful on self-hosted runners with persistent working dirs
+    # — it strips ~/.cargo/bin contents and partial-restores tarballs over
+    # files the runner already has on disk. See Swatinem/rust-cache#194.
+    # Gate on runner.environment to get the best of both.
+    - name: Cache cargo registry + target (github-hosted)
+      if: inputs.container_image != '' && runner.environment == 'github-hosted'
+      uses: Swatinem/rust-cache@v2
+      with:
+        save-if: true
+        shared-key: "rust-workspace"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # 4. cargo-nextest install (if not already on PATH)
+    # ─────────────────────────────────────────────────────────────────────────
+    # Most Nx-Rust workspaces drive tests via `cargo nextest run`. The
+    # container image / host should already have it — but this step
+    # ensures the binary is on PATH if the image author forgot.
+    # `taiki-e/install-action` is a fast pre-built-binary installer.
+    - name: Install cargo-nextest (if absent)
+      if: inputs.install_nextest == 'true'
+      shell: bash
+      run: |
+        if command -v cargo-nextest >/dev/null 2>&1; then
+          echo "✅ cargo-nextest already on PATH: $(cargo nextest --version)"
+          exit 0
+        fi
+        echo "📦 cargo-nextest not found, will install via taiki-e/install-action"
+        # Set a marker so the next step actually does the install. This
+        # split lets us avoid invoking taiki-e/install-action when the
+        # tool is already present (fast-path for container images that
+        # bake it in).
+        echo "INSTALL_NEXTEST_NEEDED=true" >> "$GITHUB_ENV"
+
+    - name: cargo-nextest install via taiki-e
+      if: env.INSTALL_NEXTEST_NEEDED == 'true'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest@${{ inputs.nextest_version }}

--- a/actions/nx-workspace-setup/action.yml
+++ b/actions/nx-workspace-setup/action.yml
@@ -1,0 +1,115 @@
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║                       NX WORKSPACE SETUP COMPOSITE ACTION                    ║
+# ╠══════════════════════════════════════════════════════════════════════════════╣
+# ║  Bootstraps an Nx workspace inside a container-mode CI job. Detects the      ║
+# ║  package manager from lockfiles and runs the frozen-lockfile install.        ║
+# ║  ALWAYS needed in container mode (because nx itself is a Node package),     ║
+# ║  regardless of what languages the workspace's app code is written in.        ║
+# ║                                                                              ║
+# ║  Why this is NOT a "TypeScript pack":                                        ║
+# ║    A pure-Rust workspace using Nx (e.g. mcpg-dev/source-code with           ║
+# ║    @monodon/rust) still needs Node + pnpm to run `pnpm nx ...`. The Nx      ║
+# ║    workspace bootstrap is independent of the app code's language. This       ║
+# ║    composite is mandatory; language packs (rust, go, python, …) are         ║
+# ║    additional opt-in extras on top.                                          ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+#
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ WHAT THIS DOES                                                              │
+# ├─────────────────────────────────────────────────────────────────────────────┤
+# │ 1. Detect package manager from lockfile (bun → pnpm → yarn → npm).         │
+# │ 2. Run the manager's frozen-lockfile install command.                      │
+# │                                                                             │
+# │ Does NOT install Node, pnpm, yarn, npm, or bun — those are expected to be  │
+# │ baked into the container image. For host mode, environment-setup handles    │
+# │ the install via .environment.yml. For non-container github-hosted callers   │
+# │ who want auto-install, use actions/setup-node directly instead.             │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
+name: "Nx Workspace Setup"
+description: |
+  Install the Nx workspace's Node dependencies inside a container-mode
+  CI job. Auto-detects the package manager from the lockfile and runs
+  the frozen-lockfile install. Does NOT install the manager itself —
+  the container image is expected to provide it.
+
+inputs:
+  working_directory:
+    description: |
+      Working directory for the install. Defaults to the repo root.
+      Override for nested Nx workspaces or monorepos with multiple
+      Nx instances.
+    required: false
+    default: "."
+
+  frozen_lockfile:
+    description: |
+      Whether to use the frozen-lockfile install. `true` rejects any
+      lockfile drift (the CI default); `false` allows updates.
+    required: false
+    default: "true"
+
+outputs:
+  manager:
+    description: "Detected package manager (pnpm / yarn / npm / bun)"
+    value: ${{ steps.pm.outputs.manager }}
+
+  exec:
+    description: |
+      Command prefix for invoking a Node-installed binary from
+      downstream steps. e.g. `pnpm nx` for pnpm workspaces.
+    value: ${{ steps.pm.outputs.exec }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect package manager
+      id: pm
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        set -euo pipefail
+        if [ -f bun.lockb ] || [ -f bun.lock ]; then
+          echo "manager=bun" >> "$GITHUB_OUTPUT"
+          echo "exec=bun"     >> "$GITHUB_OUTPUT"
+          echo "📦 detected: bun"
+        elif [ -f pnpm-lock.yaml ]; then
+          echo "manager=pnpm" >> "$GITHUB_OUTPUT"
+          echo "exec=pnpm"    >> "$GITHUB_OUTPUT"
+          echo "📦 detected: pnpm"
+        elif [ -f yarn.lock ]; then
+          echo "manager=yarn" >> "$GITHUB_OUTPUT"
+          echo "exec=yarn"    >> "$GITHUB_OUTPUT"
+          echo "📦 detected: yarn"
+        elif [ -f package-lock.json ]; then
+          echo "manager=npm" >> "$GITHUB_OUTPUT"
+          echo "exec=npx"    >> "$GITHUB_OUTPUT"
+          echo "📦 detected: npm"
+        else
+          echo "::warning::No lockfile found in ${{ inputs.working_directory }} — skipping install"
+          echo "manager=" >> "$GITHUB_OUTPUT"
+          echo "exec=npx"  >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install workspace dependencies
+      if: steps.pm.outputs.manager != ''
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        set -euo pipefail
+        FROZEN_FLAG=""
+        case "${{ steps.pm.outputs.manager }}" in
+          pnpm)
+            ${{ inputs.frozen_lockfile == 'true' && 'pnpm install --frozen-lockfile --prefer-offline' || 'pnpm install --prefer-offline' }}
+            ;;
+          yarn)
+            ${{ inputs.frozen_lockfile == 'true' && 'yarn install --frozen-lockfile' || 'yarn install' }}
+            ;;
+          npm)
+            ${{ inputs.frozen_lockfile == 'true' && 'npm ci' || 'npm install' }}
+            ;;
+          bun)
+            ${{ inputs.frozen_lockfile == 'true' && 'bun install --frozen-lockfile' || 'bun install' }}
+            ;;
+        esac
+        echo "✅ workspace deps installed via ${{ steps.pm.outputs.manager }}"

--- a/docs/REUSABLE_WORKFLOWS.md
+++ b/docs/REUSABLE_WORKFLOWS.md
@@ -1,0 +1,262 @@
+# Reusable workflows — design + the `@v5` language-agnostic shape
+
+The reusable workflows in `tsok-org/.github` follow one architectural rule:
+
+> **The reusable workflows are language-agnostic.** They orchestrate Nx and
+> standard CI primitives (checkout, set-shas, install, run, summarise) and
+> nothing more. Anything language-specific (toolchain config, target-dir
+> scoping, language-specific cache strategies, tool installs) lives in a
+> dedicated **composite action**, gated behind an opt-in input.
+
+Adding a new language (Go, Python, C, Java, …) means adding a new composite
+action — **never** editing the reusable workflows themselves.
+
+---
+
+## Architecture at a glance
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  WORKFLOWS  (language-agnostic)                                          │
+│  ────────────────────────────                                            │
+│  nx-affected-plan.yml@v5  affected graph → matrix + gates                │
+│  nx-ci.yml@v5             single-target Nx execution                     │
+│  nx-cd.yml@v4             release orchestration (Phase 7 → v5)           │
+│  dependabot-auto-merge.yml, gitleaks.yml, …                              │
+└──────────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  │ language_packs: "rust"   ─┐
+                                  │                          opt-in
+                                  ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│  COMPOSITE ACTIONS  (language-specific extras, opt-in)                   │
+│  ─────────────────────────────────────────────────                       │
+│  actions/nx-workspace-setup  Nx workspace install (auto, mandatory)      │
+│  actions/nx-rust-setup       Rust CI extras (CARGO_TARGET_DIR, …)        │
+│  (future)                                                                │
+│    actions/nx-go-setup       Go CI extras                                │
+│    actions/nx-python-setup   Python CI extras                            │
+│    actions/nx-c-setup        C/C++ CI extras                             │
+│    actions/nx-java-setup     Java CI extras                              │
+│                                                                          │
+│  HOST-MODE LEGACY                                                        │
+│  actions/environment-setup   Kitchen-sink declarative setup (.env.yml)   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Container mode vs host mode
+
+The reusable workflows support both. The distinction matters because
+language packs **only run in container mode** — host mode delegates to the
+legacy `environment-setup` composite (which is itself declarative via
+`.environment.yml`).
+
+| Mode | When | What sets up the toolchain |
+|---|---|---|
+| Container (`container_image` set) | The job runs inside a pre-built OCI image that bakes the toolchains. | The image. The `nx-workspace-setup` composite runs `pnpm install`; language packs add their CI-glue extras. |
+| Host (`container_image` empty) | Legacy v1/v2 caller path. | `actions/environment-setup` reads `.environment.yml` and installs everything on the host runner. Language packs are silently skipped. |
+
+We strongly recommend **container mode** for new repos. It's faster
+(no per-job apt/install), more reproducible (the image is the contract),
+and the language-pack architecture only makes sense there.
+
+---
+
+## Language packs
+
+A language pack is a composite action at `actions/nx-<lang>-setup/action.yml`
+that runs **before** the Nx target step. It is invoked when a caller passes
+`language_packs: "<lang>[,...]"` to `nx-ci.yml@v5` (or future `nx-cd.yml@v5`).
+
+### What a pack does
+
+Each pack handles its language's CI-glue extras — the things that aren't
+"install the toolchain" (the image's job) but also aren't "run Nx" (the
+workflow's job). Examples per language:
+
+| Language | Pack responsibilities |
+|---|---|
+| Rust (`rust`) | Validate cargo env enums; per-shard `CARGO_TARGET_DIR`; cache gating; `cargo-nextest` install if absent |
+| Go (future, `go`) | `GOPATH` per shard; `GOCACHE`; module cache; `gotestsum` install |
+| Python (future, `python`) | venv setup; pip cache; coverage tool install |
+| C/C++ (future, `c`) | `cmake` configure step; ccache / sccache; per-shard build dir |
+| Java (future, `java`) | gradle cache; per-shard build dir; `gradle wrapper` validation |
+
+### What a pack does NOT do
+
+- Install the language toolchain (rustup/go/python/javac/…). That's the
+  container image's job.
+- Run any Nx command. That's the workflow's job.
+- Mutate `nx.json` or any source files.
+
+### Adding a new language pack
+
+1. Create `actions/nx-<lang>-setup/action.yml` (use `actions/nx-rust-setup`
+   as a template).
+2. Implement the steps that handle your language's CI-glue.
+3. Add a new step in `.github/workflows/nx-ci.yml` (and `nx-cd.yml`) that
+   conditionally invokes your composite:
+   ```yaml
+   - name: <Lang> language pack
+     if: inputs.container_image != '' && contains(format(',{0},', inputs.language_packs), ',<lang>,')
+     uses: tsok-org/.github/actions/nx-<lang>-setup@main
+     with:
+       # pack-specific inputs
+   ```
+4. Document the pack in this file's "Composite actions" section below.
+5. Bump the workflow's tag (typically a minor — `@v5.1`) when you cut a
+   release that includes the new pack.
+
+The reusable workflows already accept `language_packs` as a CSV. The new
+pack name becomes a valid token in that CSV.
+
+---
+
+## Composite actions reference
+
+### `actions/nx-workspace-setup` — mandatory in container mode
+
+Bootstraps the Nx workspace by detecting the package manager from the
+lockfile and running its `--frozen-lockfile` install. Required even for
+pure-Rust workspaces because Nx itself is a Node package.
+
+Inputs:
+- `working_directory` (default `.`)
+- `frozen_lockfile` (default `true`)
+
+Outputs:
+- `manager` — detected package manager
+- `exec` — invocation prefix (e.g. `pnpm`)
+
+### `actions/nx-rust-setup` — Rust language pack
+
+Container-mode CI-glue for Rust workspaces. Runs after `nx-workspace-setup`.
+
+Inputs:
+- `target` — Nx target name (for `CARGO_TARGET_DIR` scoping)
+- `shard` / `shards_total` — shard index for per-shard target dir
+- `container_image` — passed through for the cache gating decision
+- `install_nextest` (default `true`) — install `cargo-nextest` if absent
+- `nextest_version` (default `^0.9`)
+
+Behaviour:
+1. Validate `CARGO_TERM_VERBOSE`, `CARGO_TERM_COLOR`, `RUST_BACKTRACE`
+   against allowed enums.
+2. If `shards_total > 1`, set `CARGO_TARGET_DIR=/tmp/cargo-target-<target>-<shard>`.
+3. On GitHub-hosted runners only, enable `Swatinem/rust-cache` for the
+   cargo registry + target tree.
+4. Install `cargo-nextest` if absent and `install_nextest` is `true`.
+
+---
+
+## Workflow reference
+
+### `nx-affected-plan.yml@v5`
+
+Computes the affected project set, splits it into per-target shards, and
+emits a matrix the caller fans out across runners. Language-agnostic.
+
+#### New in v5: `gates`
+
+Lets the plan emit a JSON map of boolean gates derived from the affected
+project set. Avoids needing a separate "detect affected" job to evaluate
+"does this PR touch X?" conditions.
+
+```yaml
+plan:
+  uses: tsok-org/.github/.github/workflows/nx-affected-plan.yml@v5
+  with:
+    targets: "test,integration"
+    test_shards: 3
+    integration_shards: 3
+    gates: "has_sql=mcpg-plugin-backend-sql;has_cluster=mcpg-plugin-cluster-*"
+
+# Consume:
+sql-matrix:
+  needs: plan
+  if: fromJSON(needs.plan.outputs.gates).has_sql == true
+  ...
+```
+
+### `nx-ci.yml@v5`
+
+Single-target Nx execution. Body is language-agnostic; language-specific
+behaviour lives in composites invoked via `language_packs`.
+
+#### New in v5
+
+| Input | Purpose |
+|---|---|
+| `language_packs` | CSV of language packs to enable in container mode (e.g. `"rust"`, `"rust,go"`). |
+| `target_configuration` | Nx target configuration suffix appended to the target name. E.g. `integration` + `pg17` → `integration:pg17`. |
+| `extra_env_json` | JSON object of additional env vars to export to `GITHUB_ENV` before the target runs. Useful for per-matrix-row parameterisation. |
+| `nx_powerpack_cache_mode` | Override the auto-computed `read-only`/`read-write` mode. Default empty = auto. |
+
+#### Breaking changes v4 → v5
+
+- The inline `Validate CI env vars (container mode)`, `Cache cargo registry
+  + target (container mode)`, and `Scope CARGO_TARGET_DIR per shard` steps
+  have been removed. Their behaviour moved to `actions/nx-rust-setup`. To
+  preserve v4 behaviour, callers must add `language_packs: "rust"`.
+- The hardcoded `pnpm install --frozen-lockfile` step has been replaced by
+  `actions/nx-workspace-setup`, which auto-detects pnpm/yarn/npm/bun. No
+  caller action needed unless your workspace previously relied on the
+  pnpm-only behaviour.
+
+---
+
+## Migration guide @v4 → @v5
+
+For Rust-based Nx workspaces (the existing v4 use case):
+
+```diff
+ pr-validate:
+-  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v4
++  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v5
+   with:
++    language_packs: "rust"
+     lint: true
+     build: true
+     ...
+```
+
+For TypeScript-only workspaces:
+
+```diff
+ pr-validate:
+-  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v4
++  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v5
+   with:
++    # language_packs intentionally empty — nx-workspace-setup is implicit.
+     lint: true
+     test: true
+     build: true
+```
+
+For per-DB-engine matrix callers (new pattern):
+
+```yaml
+sql-matrix:
+  needs: plan
+  if: fromJSON(needs.plan.outputs.gates).has_sql == true
+  strategy:
+    matrix:
+      include:
+        - { config: pg14, image: postgres:14-alpine, scheme: postgres }
+        - { config: pg17, image: postgres:17-alpine, scheme: postgres }
+  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v5
+  with:
+    language_packs: "rust"
+    target: integration
+    target_configuration: ${{ matrix.config }}
+    projects: my-sql-plugin
+    extra_env_json: |
+      {"POSTGRES_TEST_URL": "${{ matrix.scheme }}://u:p@postgres:5432/db"}
+    container_image: ghcr.io/myorg/build-env:ci-latest
+    container_options: --volume /var/run/docker.sock:/var/run/docker.sock
+  # NOTE: services: blocks can't be expressed via a reusable-workflow
+  # input today — DB-matrix callers that need GH `services:` containers
+  # currently stay inline in the consumer workflow.
+```


### PR DESCRIPTION
## Summary

Splits the previously monolithic `nx-ci.yml@v4` into a **language-agnostic workflow body** + per-language **composite actions**. The reusable workflow only knows about Nx; anything language-specific (CARGO_TARGET_DIR scoping, env validation, cache strategies, tool installs) lives in a composite invoked via an opt-in `language_packs` CSV input.

Adding a new language (Go, Python, C, Java, …) means **adding a new composite at `actions/nx-<lang>-setup/`** plus a one-line conditional step in `nx-ci.yml` — the workflow body never grows language-specific code.

## What's in this PR

### New composite actions

- **`actions/nx-workspace-setup`** — bootstraps the Nx workspace by auto-detecting the package manager (pnpm/yarn/npm/bun) and running the frozen-lockfile install. Mandatory in container mode because Nx itself is a Node package, regardless of app-code language.
- **`actions/nx-rust-setup`** — Rust language pack. Container-mode CI-glue: cargo env enum validation, per-shard CARGO_TARGET_DIR scoping, Swatinem/rust-cache gating (github-hosted only), optional cargo-nextest install. Does NOT install the Rust toolchain (that's the container image's job).

### `nx-affected-plan.yml` — `gates` input/output

New ` gates` input takes semicolon-separated `name=pattern` pairs. Each pattern is matched against the affected project set; the workflow emits a JSON map (`{"has_sql": true, ...}`) as the `gates` output. Replaces ad-hoc "detect affected" jobs in consumer workflows.

\`\`\`yaml
plan:
  uses: tsok-org/.github/.github/workflows/nx-affected-plan.yml@v5
  with:
    targets: \"test,integration\"
    test_shards: 3
    integration_shards: 3
    gates: \"has_sql=mcpg-plugin-backend-sql;has_cluster=mcpg-plugin-cluster-*\"

# Consume:
sql-matrix:
  needs: plan
  if: fromJSON(needs.plan.outputs.gates).has_sql == true
\`\`\`

### `nx-ci.yml@v5` — language-agnostic body

**Breaking changes (consumers must opt back in to preserve v4 behavior):**

- Removed inline `Validate CI env vars`, `Cache cargo registry + target`, and `Scope CARGO_TARGET_DIR per shard` steps. These were Rust-only; their behavior moved to `actions/nx-rust-setup`. Restore by adding `language_packs: \"rust\"`.
- Removed hardcoded `pnpm install --frozen-lockfile`. Replaced by `actions/nx-workspace-setup` which auto-detects pnpm/yarn/npm/bun. No caller action needed unless your workspace specifically required pnpm-only behavior.

**New inputs:**

| Input | Purpose |
|---|---|
| `language_packs` | CSV of language packs to enable in container mode (e.g. `\"rust\"`). |
| `target_configuration` | Nx target configuration suffix appended to the target name (e.g. `integration` + `pg17` → `integration:pg17`). |
| `extra_env_json` | JSON object of additional env vars to export to GITHUB_ENV before the target runs. |
| `nx_powerpack_cache_mode` | Override the auto-computed read-only/read-write CREEP cache mode. |

### Docs

`docs/REUSABLE_WORKFLOWS.md` covers the architecture, language-pack contract, the current pack reference, and a v4→v5 migration guide.

## Migration

For Rust-based Nx workspaces (the existing v4 use case):

\`\`\`diff
 pr-validate:
-  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v4
+  uses: tsok-org/.github/.github/workflows/nx-ci.yml@v5
   with:
+    language_packs: \"rust\"
     lint: true
     build: true
\`\`\`

For TypeScript-only workspaces, just bump the ref — `language_packs` empty is fine.

## Release plan

After merge, **tag `v5`** on main so consumers can reference `@v5`. `@v4` continues to point at the existing commit and is unaffected.

## Test plan

- [ ] Self-test workflow passes on this PR branch
- [ ] mcpg-dev/source-code adopts `@v5` (separate PR — already prepared)
- [ ] One full CI cycle in mcpg-dev validates the new shape end-to-end
- [ ] Tag `v5` after merge